### PR TITLE
Use include_lib in proper.hrl to make it painless to include_lib proper/i

### DIFF
--- a/include/proper.hrl
+++ b/include/proper.hrl
@@ -23,7 +23,7 @@
 %%% @doc User header file: This file should be included in each file containing
 %%%      user type declarations and/or properties to be tested.
 
--include("proper_common.hrl").
+-include_lib("proper/include/proper_common.hrl").
 
 -ifndef(PROPER_NO_IMPORTS).
 


### PR DESCRIPTION
Use include_lib in proper.hrl to make it painless to include_lib proper/include/proper.hrl without having to add proper/include to the list of include paths
