### PR TITLE
Memory consumption fix

### DIFF
--- a/include/proper_common.hrl
+++ b/include/proper_common.hrl
@@ -43,7 +43,7 @@
 -define(FORCE(X), (X)()).
 -define(DELAY(X), fun() -> X end).
 -define(LAZY(X), proper_types:lazy(?DELAY(X))).
--define(SIZED(SizeArg,Gen), proper_types:sized(fun(SizeArg) -> Gen end)).
+-define(SIZED(SizeArg,Gen), proper_types:sized(fun(_, SizeArg) -> Gen end)).
 -define(LET(X,RawType,Gen), proper_types:bind(RawType,fun(X) -> Gen end,false)).
 -define(SHRINK(Gen,AltGens),
 	proper_types:shrinkwith(?DELAY(Gen),?DELAY(AltGens))).

--- a/src/proper_gen.erl
+++ b/src/proper_gen.erl
@@ -269,8 +269,9 @@ contains_fun(_Term) ->
 normal_gen(Type) ->
     Gen = proper_types:get_prop(generator, Type),
     if
-	is_function(Gen, 0) -> Gen();
-	is_function(Gen, 1) -> Gen(proper:get_size(Type))
+  is_function(Gen, 0) -> Gen();
+	is_function(Gen, 1) -> Gen(Type);
+	is_function(Gen, 2) -> Gen(Type, proper:get_size(Type))
     end.
 
 %% @private
@@ -483,7 +484,7 @@ loose_tuple_gen(Size, ElemType) ->
 loose_tuple_rev(Tuple, ElemType) ->
     CleanList = tuple_to_list(Tuple),
     List = case proper_types:find_prop(reverse_gen, ElemType) of
-	       {ok,ReverseGen} -> [ReverseGen(X) || X <- CleanList];
+	       {ok,ReverseGen} -> [ReverseGen(ElemType,X) || X <- CleanList];
 	       error           -> CleanList
 	   end,
     {'$used', List, Tuple}.

--- a/src/proper_shrink.erl
+++ b/src/proper_shrink.erl
@@ -345,7 +345,7 @@ remove_shrinker(Instance, Type, {shrunk,1,{indices,Checked,_ToCheck}}) ->
     %%       compares elements with == instead of =:=, that could cause us to
     %%       miss some elements in some cases
     GetIndices = proper_types:get_prop(get_indices, Type),
-    Indices = ordsets:from_list(GetIndices(Instance)),
+    Indices = ordsets:from_list(GetIndices(Type, Instance)),
     NewToCheck = ordsets:subtract(Indices, Checked),
     remove_shrinker(Instance, Type, {indices,Checked,NewToCheck}).
 
@@ -369,7 +369,7 @@ elements_shrinker(Instance, Type, init) ->
 			    proper_types:get_prop(internal_types, Type),
 			fun(I) -> Retrieve(I, InnerTypes) end
 		end,
-	    Indices = GetIndices(Instance),
+	    Indices = GetIndices(Type, Instance),
 	    elements_shrinker(Instance, Type, {inner,Indices,GetElemType,init});
 	_ ->
 	    {[], done}


### PR DESCRIPTION
This change makes PropEr use memory rationally by not passing the entire tree with Funs' envs up through the chain

Basically, we ran into an understanding that PropEr totally blows up memory under certain circumstances.

Example:

``` erlang
%% Original PropEr
1> erts_debug:size(proper_types:list(proper_types:list(proper_types:list(proper_types:frequency([{1, proper_types:union([lists:seq(1,40)])},{2, proper_types:union(lists:seq(1,40))}]))))).

2568396

%% Our PropEr
1> erts_debug:size(proper_types:list(proper_types:list(proper_types:list(proper_types:frequency([{1, proper_types:union([lists:seq(1,40)])},{2, proper_types:union(lists:seq(1,40))}]))))).
3745
```
