### PR TITLE
Don't recompile the PropEr over and over again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,9 @@ default: compile
 
 all: compile doc
 
+include/compile_flags.hrl:
+	./write_compile_flags $@
+
 compile:
 	./rebar compile
 

--- a/rebar.config
+++ b/rebar.config
@@ -34,5 +34,5 @@
 	    warn_missing_spec, warn_untyped_record]}.
 {dialyzer_opts, [{warnings,[unmatched_returns]}]}.
 
-{pre_hooks, [{compile,"./write_compile_flags include/compile_flags.hrl"}]}.
+{pre_hooks, [{compile,"make include/compile_flags.hrl"}]}.
 {post_hooks, [{clean,"./clean_doc.sh"}]}.


### PR DESCRIPTION
[Pull Request 23](pr23) by @voluntas allowed PropEr to be used as a Rebar dependency in a project, but at the cost of most of the PropEr being recompiled over and over again each time `rebar compile` is called in a top-level project. This patch fixes that problem.

pr23: https://github.com/manopapad/proper/pull/23
