### PR TITLE
Reduce PropEr's memory consumption

### DIFF
--- a/src/proper_shrink.erl
+++ b/src/proper_shrink.erl
@@ -345,7 +345,7 @@ remove_shrinker(Instance, Type, {shrunk,1,{indices,Checked,_ToCheck}}) ->
     %%       compares elements with == instead of =:=, that could cause us to
     %%       miss some elements in some cases
     GetIndices = proper_types:get_prop(get_indices, Type),
-    Indices = ordsets:from_list(GetIndices(Instance)),
+    Indices = ordsets:from_list(GetIndices(Type, Instance)),
     NewToCheck = ordsets:subtract(Indices, Checked),
     remove_shrinker(Instance, Type, {indices,Checked,NewToCheck}).
 
@@ -369,7 +369,7 @@ elements_shrinker(Instance, Type, init) ->
 			    proper_types:get_prop(internal_types, Type),
 			fun(I) -> Retrieve(I, InnerTypes) end
 		end,
-	    Indices = GetIndices(Instance),
+	    Indices = GetIndices(Type, Instance),
 	    elements_shrinker(Instance, Type, {inner,Indices,GetElemType,init});
 	_ ->
 	    {[], done}


### PR DESCRIPTION
Although R15B01 performs much better memory wise as mentioned by @kostis in #30, there are still problems particularly with vectors and unions.

One easy way to trigger them is to use proper_stdgen:email() from [proper_stdlib](https://github.com/spawngrid/proper_stdlib). With R15B01 and PropEr's current master this exhausts all available memory. The problem can be narrowed further down to proper_stdgen:email_local_part().
With this branch the problem doesn't trigger.

This patch replaces the ones in #19 and #31 using the same approach but a slightly different implementation to keep dialyzer happy.
