### PR TITLE
don't clean the stacktrace if the error is a bad use of a proper function

### DIFF
--- a/src/proper.erl
+++ b/src/proper.erl
@@ -1399,7 +1399,12 @@ threw_exception_aux(Fun, TopMod, TopName, TopArgs) ->
 -spec clean_stacktrace(stacktrace()) -> stacktrace().
 clean_stacktrace(RawTrace) ->
     {Trace,_Rest} = lists:splitwith(fun is_not_proper_call/1, RawTrace),
-    Trace.
+    %% If the clean trace is empty it's probably because of a bad call to
+    %% the proper API, so we let the whole stacktrace through
+    case Trace of
+        [] -> RawTrace;
+        _ -> Trace
+    end.
 
 -spec is_not_proper_call(call_record()) -> boolean().
 -ifdef(OLD_STACKTRACE_FORMAT).


### PR DESCRIPTION
I had a bad time debugging a stupid error in a FSM property. Next simplified (and untested) snippet shows that I mistakenly called the non-existing function proper_fsm:run_commands/1

``` erlang
prop_bad_fsm() ->
    ?FORALL(
       Cmds, proper_fsm:commands(?MODULE),
       {H, S, R} = proper_fsm:run_commands(Cmds),
       ?WHENFAIL(report_error(H, S, R), R =:= ok)).
```

This will fail with undef and an empty stracktrace, which is very confusing until you realise what's going on:

```
!
Failed: After 1 test(s).
An exception was raised: error:undef.
Stacktrace: [].
[]
```

With this patch the trace would be something like

```
!
Failed: After 1 test(s).
An exception was raised: error:undef.
Stacktrace: [{proper_fsm,run_commands,
                         [[{set,{var,1},{foo,bar,[]}}]],
                         []},
             {test_proper,'-prop_bad_call_fsm/0-fun-2-',3,
                              [{file,"test_proper.erl"},{line,100}]},
             {proper,apply_args,3,[{file,"src/proper.erl"},{line,1327}]},
             {proper,child,3,[{file,"src/proper.erl"},{line,1366}]}].
```

Which I think is more informative despite of the extra glibberish.

In any other case, the stacktrace will be as clean as before :)
