### PR TITLE
Allows clean build on Windows without make

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -34,5 +34,6 @@
 	    warn_missing_spec, warn_untyped_record]}.
 {dialyzer_opts, [{warnings, [unmatched_returns]}]}.
 
-{pre_hooks, [{compile, "make include/compile_flags.hrl"}]}.
+{pre_hooks, [{"(linux|bsd|darwin|solaris)", compile, "make include/compile_flags.hrl"},
+		{"win32", compile, "escript.exe write_compile_flags include/compile_flags.hrl"}]}.
 {post_hooks, [{clean, "./clean_doc.sh"}]}.


### PR DESCRIPTION
Fixes #40, using patch based off @slowbro13's original patch. Adding .exe suffix ensures escript can be called successfully on Erlang < R15B02.

Windows by default does not have a working make. This patch ensures
pure Erlang apps can be built with PropEr support despite the lack
of a native make command.

NB rebar compile succeeds with some warnings below, using R15B02:

```
Z:\repos\proper>rebar compile
==> proper (compile)
Compiled src/strip_types.erl
Compiled src/vararg.erl
Compiled src/proper_transformer.erl
Compiled src/proper_prop_remover.erl
Compiled src/proper_fsm.erl
Compiled src/proper_statem.erl
Compiled src/proper_orddict.erl
Compiled src/proper_symb.erl
Compiled src/proper_sets.erl
Compiled src/proper_array.erl
Compiled src/proper_gb_sets.erl
Compiled src/proper_dict.erl
Compiled src/proper.erl
Compiled src/proper_gb_trees.erl
Compiled src/proper_gen.erl
Compiled src/proper_shrink.erl
Compiled src/proper_arith.erl
src/proper_types.erl:343: Warning: missing specification for function from_binary/1
src/proper_types.erl:460: Warning: missing specification for function unwrap/1
z:/repos/proper/src/proper_types.erl:343: Warning: missing specification for function from_binary/1
z:/repos/proper/src/proper_types.erl:460: Warning: missing specification for function unwrap/1
Compiled src/proper_types.erl
Compiled src/proper_ordsets.erl
Compiled src/proper_typeserver.erl
Compiled src/proper_queue.erl
```
