### PR TITLE
More reliable check_spec'ing for Cover-compiled modules.

### DIFF
--- a/src/proper_typeserver.erl
+++ b/src/proper_typeserver.erl
@@ -606,15 +606,15 @@ get_exp_info(Mod) ->
 -spec get_code_and_exports(mod_name()) ->
 	  rich_result2([abs_form()],mod_exp_funs()).
 get_code_and_exports(Mod) ->
-    case code:which(Mod) of
-	ObjFileName when is_list(ObjFileName) ->
-	    case get_chunks(ObjFileName) of
+    case code:get_object_code(Mod) of
+	{Mod, ObjBin, _ObjFileName} ->
+	    case get_chunks(ObjBin) of
 		{ok,_AbsCode,_ModExpFuns} = Result ->
 		    Result;
 		{error,Reason} ->
 		    get_code_and_exports_from_source(Mod, Reason)
 	    end;
-	_ErrAtom when is_atom(_ErrAtom) ->
+	error ->
 	    get_code_and_exports_from_source(Mod, cant_find_object_file)
     end.
 


### PR DESCRIPTION
check_spec indirectly used code:which/0 to load the BEAM of a targeted
module.   If the module was compiled with {cover_enabled, true}, proper
failed to load the BEAM and resorted to recompiling the module with a
hardcode list of compilation options.  If the targeted module depended
on any additional flags (such as include dirs), the compilation failed
and check_spec returned an error.

This fix uses code:get_object_code/1 (instead of code:which/1) to
retrieve the BEAM for a given module, sidestepping the need to
recompile any Cover-compiled modules.
