### PR TITLE
Permit caller to "prime" PropEr's typeserver and random generator prior to testing

### DIFF
--- a/src/proper.erl
+++ b/src/proper.erl
@@ -633,8 +633,8 @@ global_state_init(#opts{start_size = StartSize, constraint_tries = CTries,
         _ ->
             Seed
     end,
-    proper_arith:rand_start(S),
-    proper_typeserver:start(),
+    proper_arith:rand_restart(S),
+    proper_typeserver:restart(),
     ok.
 
 -spec global_state_reset(opts()) -> 'ok'.

--- a/src/proper_arith.erl
+++ b/src/proper_arith.erl
@@ -30,7 +30,7 @@
 	 safe_any/2, safe_zip/2, tuple_map/2, cut_improper_tail/1,
 	 head_length/1, find_first/2, filter/2, partition/2, remove/2, insert/3,
 	 unflatten/2]).
--export([rand_start/1, rand_reseed/0, rand_stop/0,
+-export([rand_start/1, rand_restart/1, rand_reseed/0, rand_stop/0,
 	 rand_int/1, rand_int/2, smart_rand_int/3, rand_non_neg_int/1,
 	 rand_float/1, rand_float/2, rand_non_neg_float/1,
 	 distribute/2, jumble/1, rand_choose/1, freq_choose/1]).
@@ -216,6 +216,17 @@ rand_start(Seed) ->
     _ = ?RANDOM_MOD:seed(Seed),
     %% TODO: read option for RNG bijections here
     ok.
+
+%% @doc Conditionally seeds the random number generator. This function should be run before
+%% calling any random function from this module.
+-spec rand_restart(seed()) -> 'ok'.
+rand_restart(Seed) ->
+    case get(?SEED_NAME) of
+        undefined ->
+            rand_start(Seed);
+        _ ->
+            ok
+    end.
 
 -spec rand_reseed() -> 'ok'.
 rand_reseed() ->

--- a/src/proper_typeserver.erl
+++ b/src/proper_typeserver.erl
@@ -161,7 +161,7 @@
 -behaviour(gen_server).
 -export([demo_translate_type/2, demo_is_instance/3]).
 
--export([start/0, stop/0, create_spec_test/3, get_exp_specced/1, is_instance/3,
+-export([start/0, restart/0, stop/0, create_spec_test/3, get_exp_specced/1, is_instance/3,
 	 translate_type/1]).
 -export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
 	 code_change/3]).
@@ -312,6 +312,15 @@ start() ->
     {ok,TypeserverPid} = gen_server:start_link(?MODULE, dummy, []),
     put('$typeserver_pid', TypeserverPid),
     ok.
+
+%% @private
+-spec restart() -> 'ok'.
+restart() ->
+    TypeserverPid = get('$typeserver_pid'),
+    case (TypeserverPid =:= undefined orelse not is_process_alive(TypeserverPid)) of
+        true -> start();
+        false -> ok
+    end.
 
 %% @private
 -spec stop() -> 'ok'.


### PR DESCRIPTION
The motivation of this change request is to permit testing of a
module's exported functions by using both PropEr _and_ Meck.  Before
Meck is enabled to mock a module, the cache of PropEr's typeserver
must be first populated.  Otherwise, PropEr is unable to gather a
module's specs.

Sample code to illustrate this technique:

```
-spec check_specs(module()) -> term().
check_specs(Mod) ->
    %% pass through to the original Function Under Test (FUT)
    check_specs(Mod, fun(_Module, _Fun, Args) -> meck:passthrough(Args) end, [], []).

-spec check_specs(module(), fun((module(), atom(), list()) -> term())) -> term().
check_specs(Mod, FUT) ->
    check_specs(Mod, FUT, [], []).

-spec check_specs(module(), fun((module(), atom(), list()) -> term()), proplist()) -> term().
check_specs(Mod, FUT, PropErOptions) ->
    check_specs(Mod, FUT, PropErOptions, []).

-spec check_specs(module(), fun((module(), atom(), list()) -> term()), proplist(), proplist()) -> term().
check_specs(Mod, FUT, PropErOptions, MeckOptions) ->
    proper:global_state_erase(),
    proper:global_state_init_size(1),
    case proper_typeserver:get_exp_specced(Mod) of
        {ok, MFAs} ->
            meck:new(Mod, MeckOptions),
            try
                %% @NOTE Expand MFA clauses for larger arity as needed
                Fun = fun({M,F,0}) ->
                              meck:expect(M,F, fun() -> FUT(M, F, []) end);
                         ({M,F,1}) ->
                              meck:expect(M,F, fun(A1) -> FUT(M, F, [A1]) end);
                         ({M,F,2}) ->
                              meck:expect(M,F, fun(A1, A2) -> FUT(M, F, [A1, A2]) end)
                      end,
                lists:foreach(Fun, MFAs),
                proper:check_specs(Mod, PropErOptions)
            after
                meck:unload(Mod)
            end;
        {error,Reason} ->
            error(Reason, [Mod, PropErOptions, MeckOptions])
    end.
```
