### PR TITLE
Remove "deps/*/ebin" from dialyzer command-line arguments in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -36,7 +36,7 @@ compile:
 	./rebar compile
 
 dialyzer: compile
-	dialyzer -n -nn -Wunmatched_returns ebin deps/*/ebin
+	dialyzer -n -nn -Wunmatched_returns ebin
 
 check_escripts:
 	./check_escripts.sh make_doc write_compile_flags


### PR DESCRIPTION
The deps directory is never created since PropEr doesn't have any
depends in the rebar.config file.  Thus, "make dialyzer" fails unless
this command-line argument is removed in Makefile.
