### PR TITLE
Simplify `make` steps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Copyright 2010-2013 Manolis Papadakis <manopapad@gmail.com>,
-#                     Eirini Arvaniti <eirinibob@gmail.com>
-#                 and Kostis Sagonas <kostis@cs.ntua.gr>
+#											Eirini Arvaniti <eirinibob@gmail.com>
+#									and Kostis Sagonas <kostis@cs.ntua.gr>
 #
 # This file is part of PropEr.
 #
@@ -11,18 +11,18 @@
 #
 # PropEr is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
-# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.	See the
 # GNU General Public License for more details.
 #
 # You should have received a copy of the GNU General Public License
-# along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
+# along with PropEr.	If not, see <http://www.gnu.org/licenses/>.
 
-# Author(s):   Manolis Papadakis, Kostis Sagonas
+# Author(s):	 Manolis Papadakis, Kostis Sagonas
 # Description: Instructions for make
 
 .PHONY: default fast all get-deps compile dialyzer check_escripts tests doc clean distclean rebuild retest
 
-default: fast dialyzer
+default: fast
 
 fast: get-deps compile
 
@@ -38,7 +38,7 @@ compile:
 	./rebar compile
 
 dialyzer: compile
-	dialyzer -n -nn -Wunmatched_returns ebin $(find .  -path 'deps/*/ebin/*.beam')
+	dialyzer -n -nn -Wunmatched_returns ebin $(find .	 -path 'deps/*/ebin/*.beam')
 
 check_escripts:
 	./check_escripts.sh make_doc write_compile_flags

--- a/README.md
+++ b/README.md
@@ -81,9 +81,9 @@ Quickstart guide
 
         git clone git://github.com/manopapad/proper.git
 
-*   Compile PropEr: Run `make fast` if you just want to build PropEr, optionally
-    followed by a `make tests` to also run its unit tests. (A plain `make` call
-    does a `make fast` but also runs dialyzer on PropEr's code base; this
+*   Compile PropEr: Run `make` if you just want to build PropEr, optionally
+    followed by a `make tests` to also run its unit tests. `make fast dialyzer`
+    does a `make fast` and also runs dialyzer on PropEr's code base; this
     requires having a dialyzer PLT. To also build PropEr's documentation issue
     a `make all` call; in that case, you are going to need the `syntax_tools`
     application and a recent version of `EDoc`).
@@ -137,7 +137,7 @@ so normally PropEr output is not visible when `proper:quickcheck()` is
 invoked from EUnit. You can work around this by passing the option
 `{to_file, user}` to `proper:quickcheck/2`. For example:
 
-	   ?assertEqual(true, proper:quickcheck(your_mod:some_prop(), [{to_file, user}]).
+       ?assertEqual(true, proper:quickcheck(your_mod:some_prop(), [{to_file, user}]).
 
 This will make PropEr properties visible also when invoked from EUnit.
 


### PR DESCRIPTION
Disable dialyzer by default, so that `make` works as expected.
