### PR TITLE
Fix compilation on Windows.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,14 @@
 
 .PHONY: default fast all get-deps compile dialyzer check_escripts tests doc clean distclean rebuild retest
 
+ifeq (,$(findstring /Windows/,$(OS)))
+    SEP := $(strip \)
+else
+    SEP := $(strip /)
+endif
+
+REBAR := .$(SEP)rebar
+
 default: fast dialyzer
 
 fast: get-deps compile
@@ -32,10 +40,10 @@ include/compile_flags.hrl:
 	./write_compile_flags $@
 
 get-deps:
-	./rebar get-deps
+	$(REBAR) get-deps
 
 compile:
-	./rebar compile
+	$(REBAR) compile
 
 dialyzer: compile
 	dialyzer -n -nn -Wunmatched_returns ebin $(find .  -path 'deps/*/ebin/*.beam')
@@ -44,7 +52,7 @@ check_escripts:
 	./check_escripts.sh make_doc write_compile_flags
 
 tests: compile
-	./rebar eunit
+	$(REBAR) eunit
 
 doc:
 	./make_doc
@@ -54,11 +62,11 @@ clean:
 
 distclean: clean
 	rm -f include/compile_flags.hrl
-	./rebar clean
+	$(REBAR) clean
 
 rebuild: distclean include/compile_flags.hrl
-	./rebar compile
+	$(REBAR) compile
 
 retest: compile
 	rm -rf .eunit
-	./rebar eunit
+	$(REBAR) eunit

--- a/rebar.cmd
+++ b/rebar.cmd
@@ -1,0 +1,7 @@
+@echo off
+
+setlocal
+
+set rebarscript=%~f0
+
+escript.exe "%rebarscript:.cmd=%" %*


### PR DESCRIPTION
Hi,

I tried to use PropER on Windows, however the compilation failed. I've adjusted the Makefile to work on Windows (while also retaining Linux compatibility) and added a rebar.cmd file to ensure the 'rebar' command can be invoked.

Would I consider including this in the PropER branch?

Best regards,
--Martin
