### PR TITLE
Force use of GNU Make on FreeBSD

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -33,6 +33,7 @@
 	    warn_obsolete_guard, warn_unused_import,
 	    warn_missing_spec, warn_untyped_record]}.
 
-{pre_hooks, [{"(linux|bsd|darwin|solaris)", compile, "make include/compile_flags.hrl"},
+{pre_hooks, [{"(linux|darwin|solaris)", compile, "make include/compile_flags.hrl"},
+             {"(freebsd|netbsd|openbsd)", compile, "gmake include/compile_flags.hrl"},
 		{"win32", compile, "escript.exe write_compile_flags include/compile_flags.hrl"}]}.
 {post_hooks, [{clean, "./clean_doc.sh"}]}.


### PR DESCRIPTION
The Makefile is not compatible with BSD make, and will produce the
following error when used on FreeBSD:

  Error expanding embedded variable.
  ERROR: Command [compile] failed!

Also, os:type/0 will probably never return a generic "bsd" as the
operating system: according to os(3), the value from "uname -s" will be
used.
