### PR TITLE
Fix checking for bitstring instance

### DIFF
--- a/src/proper_typeserver.erl
+++ b/src/proper_typeserver.erl
@@ -1314,8 +1314,7 @@ is_instance(X, _Mod, {type,_,binary,[BaseExpr,UnitExpr]}, _Stack) ->
 	{ok,Base} when Base >= 0 ->
 	    case eval_int(UnitExpr) of
 		{ok,Unit} when Unit >= 0 ->
-		    is_bitstring(X) andalso bit_size(X) >= Base
-			andalso (bit_size(X) - Base) rem Unit =:= 0;
+		    is_bitstring(X) andalso bit_size(X) =:= Base + Unit;
 		_ ->
 		    abs_expr_error(invalid_unit, UnitExpr)
 	    end;

--- a/test/proper_specs_tests.erl
+++ b/test/proper_specs_tests.erl
@@ -39,7 +39,9 @@
          test4_fail_fp/2,
          test5_exc/2,
          test6_exc_fp/2,
-         test7_exc_fp/2]).
+         test7_exc_fp/2,
+         test8_bitstrings/0
+        ]).
 
 check1_specs_test_() ->
     ?_test(?assert(check1_specs_test())).
@@ -147,3 +149,14 @@ test6_exc_fp(Class, Any) ->
 -spec test7_exc_fp(error | exit | throw, badarg | any()) -> any().
 test7_exc_fp(Class, Any) ->
     erlang:Class(Any).
+
+-spec test8_bitstrings() ->
+    {<<_:16>>, <<_:17>>, <<_:16,_:_*1>>, <<_:8, _:_*0>>, <<_:8, _:_*1>>}.
+test8_bitstrings() ->
+    {
+     <<"ab">>,
+     <<"ab", 1:1>>,
+     <<"ab", 1:1>>,
+     <<"a">>,
+     <<"a", 1:1>>
+    }.


### PR DESCRIPTION
For the following spec:

```
-spec foo() -> <<_:16>>.
foo() ->
    <<"ab">>.
```

`check_typespecs` was failing, due to invalid assumption in `Unit` guards, with:

```
An exception was raised: error:badarith.
Stacktrace: [{proper_typeserver,is_instance,4,
                                [{file,"src/proper_typeserver.erl"},
                                 {line,1318}]},
             {proper_typeserver,'-apply_spec_test/5-fun-0-',6,
                                [{file,"src/proper_typeserver.erl"},
                                 {line,509}]},
             {proper,apply_args,3,[{file,"src/proper.erl"},{line,1359}]},
             {proper,child,3,[{file,"src/proper.erl"},{line,1398}]},
             {proper,'-spawn_link_migrate/1-fun-1-',2,
                     [{file,"src/proper.erl"},{line,675}]}].
```
