### PR TITLE
Faster default, moving dialyzing to travis or whoever runs all.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,11 +30,11 @@ endif
 
 REBAR := .$(SEP)rebar
 
-default: fast dialyzer
+default: fast
 
 fast: get-deps compile
 
-all: default doc tests
+all: fast dialyzer doc tests
 
 include/compile_flags.hrl:
 	./write_compile_flags $@


### PR DESCRIPTION
It's somewhat annoying to have to run dialyzer on proper constantly when it is a dependency, especially since no changes are being made to that directory. In our projects with proper, typically dialyzing proper is the number one bottleneck in build time. When proper is a dep, `make` is typical and I think that should be building only as opposed to building and type checking. The reason is that Travis has already ensured the types are correct for each commit, so there is no need to check again in production.
