### PR TITLE
Fix type signature of `USERNF` neighbour function.

### DIFF
--- a/src/proper_gen_next.erl
+++ b/src/proper_gen_next.erl
@@ -62,7 +62,7 @@
 -define(SLTEMP(T), adjust_temperature(T)).
 
 -type temperature() :: float().
--type nf() :: fun((term(), temperature()) -> term()).
+-type nf() :: fun((pos_integer(), temperature()) -> term()).
 -type matcher() :: fun((term(), proper_types:raw_type(), temperature()) -> term()).
 
 -spec update_caches('accept' | 'reject') -> 'ok'.

--- a/src/proper_target.erl
+++ b/src/proper_target.erl
@@ -53,7 +53,8 @@
 %%%   <dt>`?USERNF(Gen, Nf)'</dt>
 %%%   <dd>This uses the neighborhood function `Nf' instead of PropEr's
 %%%     constructed neighborhood function for this generator. The neighborhood
-%%%     function `Fun' should be of type `proper_gen_next:nf()'</dd>
+%%%     function `Fun' should be of type 
+%%%    `fun(term(), {Depth :: pos_integer(), Temperature::float()} -> term()'</dd>
 %%%   <dt>`?USERMATCHER(Gen, Matcher)'</dt>
 %%%   <dd>This overwrites the structural matching of PropEr with the user provided
 %%%     `Matcher' function. the matcher should be of type `proper_gen_next:matcher()'</dd>


### PR DESCRIPTION
The doc specified the type `-type nf() :: fun((term(), temperature()) -> term()).`
but in practice, what the user is given contains the max temperature term as called in
https://github.com/proper-testing/proper/blob/b000cc92da9ccbe1764ba4494fea71fb614872f3/src/proper_gen_next.erl#L215-L217