### PR TITLE
Introduce a more informative cant_generate error

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ dialyzer: .plt/proper_plt compile
 	dialyzer -n -nn --plt $< -Wunmatched_returns ebin $(find .  -path 'deps/*/ebin/*.beam')
 
 .plt/proper_plt: .plt
-	dialyzer --build_plt --output_plt $@ --apps erts kernel stdlib compiler crypto syntax_tools
+	dialyzer --build_plt --output_plt $@ --apps erts kernel stdlib compiler crypto syntax_tools eunit
 
 check_escripts:
 	./check_escripts.sh make_doc

--- a/src/proper.erl
+++ b/src/proper.erl
@@ -330,12 +330,13 @@
 %%%   a function of the desired arity. Please recompile PropEr with a suitable
 %%%   value for `?MAX_ARITY' (defined in `proper_internal.hrl'). This error
 %%%   should only be encountered during normal operation.</dd>
-%%% <dt>`cant_generate'</dt>
+%%% <dt>`{cant_generate, <Type>}'</dt>
 %%% <dd>The random instance generation subsystem has failed to
 %%%   produce an instance that satisfies some `?SUCHTHAT' constraint. You
 %%%   should either increase the `constraint_tries' limit, loosen the failing
-%%%   constraint, or make it non-strict. This error should only be encountered
-%%%   during normal operation.</dd>
+%%%   constraint, or make it non-strict. The `<Type>' field cantains
+%%%   useful information that can be used to identify the failing constraints.
+%%%   This error should only be encountered during normal operation.</dd>
 %%% <dt>`cant_satisfy'</dt>
 %%% <dd>All the tests were rejected because no produced test case
 %%%   would pass all `?IMPLIES' checks. You should loosen the failing `?IMPLIES'
@@ -579,7 +580,8 @@
 -type stacktrace() :: [call_record()].
 -type call_record() :: {mod_name(),fun_name(),arity() | list(),location()}.
 -type location() :: [{atom(),term()}].
--type error_reason() :: 'arity_limit' | 'cant_generate' | 'cant_satisfy'
+-type error_reason() :: 'arity_limit' | {'cant_generate',proper_types:type()}
+		      | 'cant_satisfy'
 		      | 'non_boolean_result' | 'rejected' | 'too_many_instances'
 		      | 'type_mismatch' | 'wrong_type' | {'typeserver',term()}
 		      | {'unexpected',any()} | {'unrecognized_option',term()}.
@@ -1262,9 +1264,10 @@ perform(Passed, ToPass, TriesLeft, Test, Samples, Printers,
 	    perform(Passed, ToPass, TriesLeft - 1, Test,
 		    Samples, Printers, Opts);
 	{error, Reason} = Error when Reason =:= arity_limit
-			      orelse Reason =:= cant_generate
 			      orelse Reason =:= non_boolean_result
 			      orelse Reason =:= type_mismatch ->
+	    Error;
+	{error, {cant_generate,_Type}} = Error ->
 	    Error;
 	{error, {typeserver,_SubReason}} = Error ->
 	    Error;
@@ -1554,8 +1557,8 @@ apply_args(Args, Prop, Ctx, Opts) ->
 	    end;
 	throw:'$arity_limit' ->
 	    {error, arity_limit};
-	throw:'$cant_generate' ->
-	    {error, cant_generate};
+	throw:{'$cant_generate',Type} ->
+	    {error, {cant_generate,Type}};
 	throw:{'$typeserver',SubReason} ->
 	    {error, {typeserver,SubReason}};
 	?STACKTRACE(ExcKind, ExcReason, Trace) %, is in macro
@@ -1994,10 +1997,11 @@ report_rerun_result({error,Reason}, #opts{output_fun = Print}) ->
 -spec report_error(error_reason(), output_fun()) -> 'ok'.
 report_error(arity_limit, Print) ->
     Print("Error: Couldn't produce a function of the desired arity, please "
-	  "recompile PropEr with an increased value for ?MAX_ARITY.~n", []);
-report_error(cant_generate, Print) ->
+          "recompile PropEr with an increased value for ?MAX_ARITY.~n", []);
+report_error({cant_generate,Type}, Print) ->
     Print("Error: Couldn't produce an instance that satisfies all strict "
-	  "constraints after ~b tries.~n", [get('$constraint_tries')]);
+          "constraints from ~s after ~b tries.~n",
+          [get_constraint_info(Type),get('$constraint_tries')]);
 report_error(cant_satisfy, Print) ->
     Print("Error: No valid test could be generated.~n", []);
 report_error(non_boolean_result, Print) ->
@@ -2161,3 +2165,15 @@ avg_and_last([Last], Sum, Len) ->
     {(Sum + Last) / (Len + 1), Last};
 avg_and_last([X | Rest], Sum, Len) ->
     avg_and_last(Rest, Sum + X, Len + 1).
+
+-spec get_constraint_info(proper_types:type()) -> string().
+get_constraint_info(Type) ->
+  Constraints = proper_types:get_prop(constraints, Type),
+  Sources = [get_constraint_source(C) || {C, true} <- Constraints],
+  string:join(Sources, ", ").
+
+-spec get_constraint_source(function()) -> string().
+get_constraint_source(Constraint) ->
+  {module, Module} = erlang:fun_info(Constraint, module),
+  {name, Name} = erlang:fun_info(Constraint, name),
+  lists:flatten(io_lib:format("~p:~p", [Module, Name])).

--- a/src/proper.erl
+++ b/src/proper.erl
@@ -1558,7 +1558,7 @@ apply_args(Args, Prop, Ctx, Opts) ->
 	throw:'$arity_limit' ->
 	    {error, arity_limit};
 	throw:{'$cant_generate',MFA} ->
-      {error, {cant_generate,MFA}};
+	    {error, {cant_generate,MFA}};
 	throw:{'$typeserver',SubReason} ->
 	    {error, {typeserver,SubReason}};
 	?STACKTRACE(ExcKind, ExcReason, Trace) %, is in macro

--- a/src/proper_gen.erl
+++ b/src/proper_gen.erl
@@ -168,7 +168,7 @@ generate(Type, 0, none) ->
     Constraints = proper_types:get_prop(constraints, Type),
     %% In presence of multiple failing constraints, we focus only the first one.
     [FailingConstraint|_] = [C || {C, true} <- Constraints],
-    Parent = fun_parent(FailingConstraint),
+    Parent = eunit_lib:fun_parent(FailingConstraint),
     throw({'$cant_generate', Parent});
 generate(_Type, 0, {ok,Fallback}) ->
     Fallback;
@@ -652,28 +652,3 @@ update_seed(Seed) ->
     put(?SEED_NAME, Seed).
 -endif.
 -endif.
-
-%%------------------------------------------------------------------------------
-%% Helper Function to extract the MFA containing a given fun.
-%%------------------------------------------------------------------------------
-%% NOTE: This code is extracted from OTP's module 'eunit_lib' to avoid creating
-%% a dependency from proper to eunit just for this.
-%%------------------------------------------------------------------------------
-%% @private
--spec fun_parent(function()) -> mfa().
-fun_parent(Fun) ->
-    {module, M} = erlang:fun_info(Fun, module),
-    {name, N} = erlang:fun_info(Fun, name),
-    case erlang:fun_info(Fun, type) of
-      {type, external} ->
-        {arity, A} = erlang:fun_info(Fun, arity),
-        {M, N, A};
-      {type, local} ->
-        [$-|S] = atom_to_list(N),
-        %% Not using string:split/3 here to ensure backward-compatibility
-        %% with older versions of Erlang/OTP (i.e. < 20)
-        Tokens = string:tokens(S, "/"),
-        {A, _} = string:to_integer(lists:last(Tokens)),
-        F = list_to_atom(string:join(lists:droplast(Tokens), "/")),
-        {M, F, A}
-    end.

--- a/src/proper_gen.erl
+++ b/src/proper_gen.erl
@@ -68,7 +68,7 @@
 		      | {'$to_part', imm_instance()}.
 -type instance() :: term().
 %% A value produced by the random instance generator.
--type error_reason() :: 'arity_limit' | 'cant_generate' | {'typeserver',term()}.
+-type error_reason() :: 'arity_limit' | {'cant_generate',proper_types:type()} | {'typeserver',term()}.
 
 %% @private_type
 -type sized_generator() :: fun((size()) -> imm_instance()).
@@ -115,7 +115,7 @@ safe_generate(RawType) ->
 	ImmInstance -> {ok, ImmInstance}
     catch
 	throw:'$arity_limit'            -> {error, arity_limit};
-	throw:'$cant_generate'          -> {error, cant_generate};
+	throw:{'$cant_generate',Type}   -> {error, {cant_generate,Type}};
 	throw:{'$typeserver',SubReason} -> {error, {typeserver,SubReason}}
     end.
 
@@ -162,8 +162,8 @@ remove_parameters(Type) ->
 
 -spec generate(proper_types:type(), non_neg_integer(),
 	       'none' | {'ok',imm_instance()}) -> imm_instance().
-generate(_Type, 0, none) ->
-    throw('$cant_generate');
+generate(Type, 0, none) ->
+    throw({'$cant_generate', Type});
 generate(_Type, 0, {ok,Fallback}) ->
     Fallback;
 generate(Type, TriesLeft, Fallback) ->

--- a/src/proper_statem.erl
+++ b/src/proper_statem.erl
@@ -113,8 +113,10 @@
 %%%   abstract state machine. In case precondition doesn't hold, a new call is
 %%%   chosen using the `command/1' generator. If preconditions are very strict,
 %%%   it will take a lot of tries for PropEr to randomly choose a valid command.
-%%%   Testing will be stopped in case the `constraint_tries' limit is reached
-%%%   (see the 'Options' section in the {@link proper} module documentation).
+%%%   Testing will be stopped if the `constraint_tries' limit is reached
+%%%   (see the 'Options' section in the {@link proper} module documentation) and
+%%%   a `{cant_generate,[{proper_statem,commands,4}]}' error will be produced in
+%%%   that case.
 %%%   Preconditions are also important for correct shrinking of failing
 %%%   testcases. When shrinking command sequences, we try to eliminate commands
 %%%   that do not contribute to failure, ensuring that all preconditions still

--- a/test/proper_tests.erl
+++ b/test/proper_tests.erl
@@ -983,7 +983,7 @@ false_props_test_() ->
      ?_fails(error_statem:prop_simple())].
 
 error_props_test_() ->
-    [?_errorsOut({cant_generate,{proper_tests,error_props_test_,0}},
+    [?_errorsOut({cant_generate,{?MODULE,error_props_test_,0}},
 		 ?FORALL(_, ?SUCHTHAT(X, pos_integer(), X =< 0), true)),
      ?_errorsOut(cant_satisfy,
 		 ?FORALL(X, pos_integer(), ?IMPLIES(X =< 0, true))),
@@ -1033,7 +1033,7 @@ options_test_() ->
      ?_failsWith([42], ?FORALL(_,?SHRINK(42,[0,1]),false), [noshrink]),
      ?_failsWith([42], ?FORALL(_,?SHRINK(42,[0,1]),false), [{max_shrinks,0}]),
      ?_fails(?FORALL(_,integer(),false), [fails]),
-     ?_assertRun({error,{cant_generate,{proper_tests,options_test_,0}}},
+     ?_assertRun({error,{cant_generate,{?MODULE,options_test_,0}}},
 		 ?FORALL(_,?SUCHTHAT(X,pos_integer(),X > 0),true),
 		 [{constraint_tries,0}], true),
      ?_failsWith([12],

--- a/test/proper_tests.erl
+++ b/test/proper_tests.erl
@@ -510,7 +510,8 @@ impossible_types() ->
      ?SUCHTHAT(B, binary(), lists:member(256,binary_to_list(B))),
      ?SUCHTHAT(X, exactly('Lelouch'), X =:= 'vi Brittania'),
      ?SUCHTHAT(X, utf8(), unicode:characters_to_list(X) =:= [16#D800]),
-     ?SUCHTHAT(X, utf8(1, 1), size(X) > 1)].
+     ?SUCHTHAT(X, utf8(1, 1), size(X) > 1),
+     ?SUCHTHAT(X, ?SUCHTHAT(Y, pos_integer(), Y > 0), X < 0)].
 
 impossible_native_types() ->
     [{types_test1, ["1.1","no_such_module:type1()","no_such_type()"]},
@@ -982,7 +983,7 @@ false_props_test_() ->
      ?_fails(error_statem:prop_simple())].
 
 error_props_test_() ->
-    [?_errorsOut({cant_generate,_},
+    [?_errorsOut({cant_generate,{proper_tests,error_props_test_,0}},
 		 ?FORALL(_, ?SUCHTHAT(X, pos_integer(), X =< 0), true)),
      ?_errorsOut(cant_satisfy,
 		 ?FORALL(X, pos_integer(), ?IMPLIES(X =< 0, true))),
@@ -992,8 +993,8 @@ error_props_test_() ->
 		   ?FORALL(X, integer(), ?IMPLIES(X > 5, X < 6))),
      ?_assertCheck({error,too_many_instances}, [1,ab],
 		   ?FORALL(X, pos_integer(), X < 0)),
-     ?_errorsOut({cant_generate,_}, prec_false:prop_simple()),
-     ?_errorsOut({cant_generate,_}, nogen_statem:prop_simple()),
+     ?_errorsOut({cant_generate,{proper_statem,commands,4}}, prec_false:prop_simple()),
+     ?_errorsOut({cant_generate,{nogen_statem,impossible_arg,0}}, nogen_statem:prop_simple()),
      ?_errorsOut(non_boolean_result, ?FORALL(_, integer(), not_a_boolean)),
      ?_errorsOut(non_boolean_result,
 		 ?FORALL(_, ?SHRINK(42,[0]),
@@ -1032,7 +1033,7 @@ options_test_() ->
      ?_failsWith([42], ?FORALL(_,?SHRINK(42,[0,1]),false), [noshrink]),
      ?_failsWith([42], ?FORALL(_,?SHRINK(42,[0,1]),false), [{max_shrinks,0}]),
      ?_fails(?FORALL(_,integer(),false), [fails]),
-     ?_assertRun({error,{cant_generate,_}},
+     ?_assertRun({error,{cant_generate,{proper_tests,options_test_,0}}},
 		 ?FORALL(_,?SUCHTHAT(X,pos_integer(),X > 0),true),
 		 [{constraint_tries,0}], true),
      ?_failsWith([12],

--- a/test/proper_tests.erl
+++ b/test/proper_tests.erl
@@ -511,7 +511,21 @@ impossible_types() ->
      ?SUCHTHAT(X, exactly('Lelouch'), X =:= 'vi Brittania'),
      ?SUCHTHAT(X, utf8(), unicode:characters_to_list(X) =:= [16#D800]),
      ?SUCHTHAT(X, utf8(1, 1), size(X) > 1),
-     ?SUCHTHAT(X, ?SUCHTHAT(Y, pos_integer(), Y > 0), X < 0)].
+     %% Nested constraints, of which the inner one fails
+     ?SUCHTHAT(X, ?SUCHTHAT(Y, pos_integer(), Y < 0), X > 0),
+     %% Nested constraints, of which the outer one fails
+     ?SUCHTHAT(X, ?SUCHTHAT(Y, pos_integer(), Y > 0), X < 0),
+     %% Nested constraints, one strict and one non-strict, where the inner one fails
+     ?SUCHTHATMAYBE(_X, ?SUCHTHAT(Y, pos_integer(), Y < 0), true),
+     %% Nested constraints, one strict and one non-strict, where the outer one fails
+     ?SUCHTHAT(X, ?SUCHTHATMAYBE(Y, pos_integer(), Y < 0), X < 0),
+     %% Two failing constraints within a ?LET macro, where one
+     %% constraint is used as the 'raw type' and one is used as the 'generator'
+     ?LET(Y,?SUCHTHAT(X, pos_integer(), X < 0),?SUCHTHAT(Y, pos_integer(), Y < 0)),
+     %% Two failing constraints within a ?LET macro, where both
+     %% constraints are used as a 'raw type'
+     ?LET({X,Y},{?SUCHTHAT(X1, pos_integer(), X1 < 0),?SUCHTHAT(Y1, pos_integer(), Y1 < 0)},{X,Y})
+    ].
 
 impossible_native_types() ->
     [{types_test1, ["1.1","no_such_module:type1()","no_such_type()"]},
@@ -722,6 +736,39 @@ native_shrinks_to_test_() ->
 
 cant_generate_test_() ->
     [?_test(assert_cant_generate(Type)) || Type <- impossible_types()].
+
+%%------------------------------------------------------------------------------
+%% Verify that failing constraints are correctly reported
+%%------------------------------------------------------------------------------
+
+cant_generate_constraints_test_() ->
+  [%% An impossible generator specified in the same function
+   ?_errorsOut({cant_generate, [{?MODULE, cant_generate_constraints_test_, 0}]},
+               ?FORALL(_, ?SUCHTHAT(X, pos_integer(), X =< 0), true)),
+   %% An impossible generator specified in a separate function
+   ?_errorsOut({cant_generate, [{?MODULE, impossible, 0}]},
+               ?FORALL(_X, impossible(), true)),
+   %% An impossible generator in presence of multiple constraints
+   ?_errorsOut({cant_generate, [{?MODULE, possible, 0},{?MODULE, possible_made_impossible, 0}]},
+               ?FORALL(_X, possible_made_impossible(), true)),
+   %% An impossible generator in presence of multiple, duplicated constraints
+   ?_errorsOut({cant_generate, [{?MODULE, possible, 0},{?MODULE, possible_made_impossible_2, 0}]},
+               ?FORALL(_X, possible_made_impossible_2(), true))
+  ].
+
+possible() ->
+  ?SUCHTHAT(X, pos_integer(), X > 0).
+
+impossible() ->
+  ?SUCHTHAT(X, pos_integer(), X =< 0).
+
+possible_made_impossible() ->
+  ?SUCHTHAT(X, possible(), X =< 0).
+
+possible_made_impossible_2() ->
+  ?SUCHTHAT(Y, ?SUCHTHAT(X, possible(), X =< 0), Y =< 0).
+
+%%------------------------------------------------------------------------------
 
 native_cant_translate_test_() ->
     [?_test(assert_cant_translate(Mod,TypeStr))
@@ -983,7 +1030,7 @@ false_props_test_() ->
      ?_fails(error_statem:prop_simple())].
 
 error_props_test_() ->
-    [?_errorsOut({cant_generate,{?MODULE,error_props_test_,0}},
+    [?_errorsOut({cant_generate,[{?MODULE,error_props_test_,0}]},
 		 ?FORALL(_, ?SUCHTHAT(X, pos_integer(), X =< 0), true)),
      ?_errorsOut(cant_satisfy,
 		 ?FORALL(X, pos_integer(), ?IMPLIES(X =< 0, true))),
@@ -993,8 +1040,8 @@ error_props_test_() ->
 		   ?FORALL(X, integer(), ?IMPLIES(X > 5, X < 6))),
      ?_assertCheck({error,too_many_instances}, [1,ab],
 		   ?FORALL(X, pos_integer(), X < 0)),
-     ?_errorsOut({cant_generate,{proper_statem,commands,4}}, prec_false:prop_simple()),
-     ?_errorsOut({cant_generate,{nogen_statem,impossible_arg,0}}, nogen_statem:prop_simple()),
+     ?_errorsOut({cant_generate,[{proper_statem,commands,4}]}, prec_false:prop_simple()),
+     ?_errorsOut({cant_generate,[{nogen_statem,impossible_arg,0}]}, nogen_statem:prop_simple()),
      ?_errorsOut(non_boolean_result, ?FORALL(_, integer(), not_a_boolean)),
      ?_errorsOut(non_boolean_result,
 		 ?FORALL(_, ?SHRINK(42,[0]),
@@ -1033,7 +1080,7 @@ options_test_() ->
      ?_failsWith([42], ?FORALL(_,?SHRINK(42,[0,1]),false), [noshrink]),
      ?_failsWith([42], ?FORALL(_,?SHRINK(42,[0,1]),false), [{max_shrinks,0}]),
      ?_fails(?FORALL(_,integer(),false), [fails]),
-     ?_assertRun({error,{cant_generate,{?MODULE,options_test_,0}}},
+     ?_assertRun({error,{cant_generate,[{?MODULE,options_test_,0}]}},
 		 ?FORALL(_,?SUCHTHAT(X,pos_integer(),X > 0),true),
 		 [{constraint_tries,0}], true),
      ?_failsWith([12],

--- a/test/proper_tests.erl
+++ b/test/proper_tests.erl
@@ -982,7 +982,7 @@ false_props_test_() ->
      ?_fails(error_statem:prop_simple())].
 
 error_props_test_() ->
-    [?_errorsOut(cant_generate,
+    [?_errorsOut({cant_generate,_},
 		 ?FORALL(_, ?SUCHTHAT(X, pos_integer(), X =< 0), true)),
      ?_errorsOut(cant_satisfy,
 		 ?FORALL(X, pos_integer(), ?IMPLIES(X =< 0, true))),
@@ -992,8 +992,8 @@ error_props_test_() ->
 		   ?FORALL(X, integer(), ?IMPLIES(X > 5, X < 6))),
      ?_assertCheck({error,too_many_instances}, [1,ab],
 		   ?FORALL(X, pos_integer(), X < 0)),
-     ?_errorsOut(cant_generate, prec_false:prop_simple()),
-     ?_errorsOut(cant_generate, nogen_statem:prop_simple()),
+     ?_errorsOut({cant_generate,_}, prec_false:prop_simple()),
+     ?_errorsOut({cant_generate,_}, nogen_statem:prop_simple()),
      ?_errorsOut(non_boolean_result, ?FORALL(_, integer(), not_a_boolean)),
      ?_errorsOut(non_boolean_result,
 		 ?FORALL(_, ?SHRINK(42,[0]),
@@ -1032,7 +1032,7 @@ options_test_() ->
      ?_failsWith([42], ?FORALL(_,?SHRINK(42,[0,1]),false), [noshrink]),
      ?_failsWith([42], ?FORALL(_,?SHRINK(42,[0,1]),false), [{max_shrinks,0}]),
      ?_fails(?FORALL(_,integer(),false), [fails]),
-     ?_assertRun({error,cant_generate},
+     ?_assertRun({error,{cant_generate,_}},
 		 ?FORALL(_,?SUCHTHAT(X,pos_integer(),X > 0),true),
 		 [{constraint_tries,0}], true),
      ?_failsWith([12],


### PR DESCRIPTION
This PR attempts to address the issue #183 by introducing a more informative _cant_generate_ error in case of failure of the random instance generation subsystem due to a strict constraint (e.g. via a `?SUCHTHAT` macro). This is particularly useful for test modules defining a big number of constraints, where identifying the root cause of a failing constraint can be tricky. As a trivial example, given the following module, which contains an _impossible_ generator (`gen_2/0`):

```erlang
-module(test).
-include_lib("proper/include/proper.hrl").

gen_1() ->
  ?SUCHTHAT(A, pos_integer(), A > 0).

gen_2() ->
  ?SUCHTHAT(B, pos_integer(), B < 0).

prop() ->
  ?FORALL({A, B}, {gen_1(), gen_2()}, A =:= B).
```

The current output from proper is:

```erl
2> proper:quickcheck(test:prop()).

Error: Couldn't produce an instance that satisfies all strict constraints after 50 tries.
{error,cant_generate}
```

This leaves the user in doubt if the error refers to the first or the second occorrence of `?SUCHTHAT`.

With the proposed patch, the root cause of the issue becomes more obvious:

```erl
Error: Couldn't produce an instance that satisfies all strict constraints from test:'-gen_2/0-fun-0-' after 50 tries.
{error,
    {cant_generate,
        {'$type',
            [{env,{1,inf}},
             {generator,{typed,#Fun<proper_types.13.103056237>}},
             {is_instance,{typed,#Fun<proper_types.14.103056237>}},
             {shrinkers,[#Fun<proper_types.15.103056237>]},
             {kind,basic},
             {constraints,[{#Fun<test.1.106658561>,true}]}]}}}
```
