### PR TITLE
Publish edoc to hexdocs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -6,13 +6,12 @@ defmodule Proper.Mixfile do
      version: "1.3.0",
      description: description(),
      package: package(),
-     deps: deps()]
+     deps: deps(),
+     aliases: aliases()]
   end
 
   defp deps do
-    [
-      {:ex_doc, "~> 0.14", only: :dev},
-    ]
+    []
   end
 
   defp description do
@@ -27,4 +26,8 @@ defmodule Proper.Mixfile do
      licenses: ["GPL"],
      links: %{"GitHub" => "https://github.com/proper-testing/proper"}]
    end
+
+  defp aliases do
+    [docs: "cmd ./make_doc"]
+  end
 end


### PR DESCRIPTION
It would be ideal if proper's edoc based documentation was published to hexdocs, instead of the current empty ExDocs based documentation:

<img width="877" alt="screen shot 2019-02-24 at 9 42 35 pm" src="https://user-images.githubusercontent.com/120878/53314747-37381300-387d-11e9-8346-aa9e0d429897.png">

I know it's possible to upload edoc to hexdocs because it's currently done for sbroker here: https://hexdocs.pm/sbroker/.

The [documentation for `mix hex.publish`](https://hexdocs.pm/hex/Mix.Tasks.Hex.Publish.html) provides the following info.

> Documentation will be generated by running the `mix docs` task. `ex_doc` provides this task by default, but any library can be used. Or an alias can be used to extend the documentation generation. The expected result of the task is the generated documentation located in the `doc/` directory with an `index.html` file.

This PR adds a `docs` alias to your mix file so when you run `mix hex.publish` or `mix hex.publish docs`, it should automatically to hexdocs. I can't test fully because I don't have publishing permissions, but I can confirm when I run `mix hex.publish docs` it does automatically generate the edoc for the project.

I also removed the `ex_doc` dependency since doesn't seem like it's needed anymore with this change. Thanks for all of your great work on this library!