### PR TITLE
Pretty-print exception reason

### DIFF
--- a/src/proper.erl
+++ b/src/proper.erl
@@ -2032,7 +2032,7 @@ report_fail_reason(time_out, Prefix, Print) ->
 report_fail_reason({trapped,ExcReason}, Prefix, Print) ->
     Print(Prefix ++ "A linked process died with reason ~w.~n", [ExcReason]);
 report_fail_reason({exception,ExcKind,ExcReason,StackTrace}, Prefix, Print) ->
-    Print(Prefix ++ "An exception was raised: ~w:~w.~n", [ExcKind,ExcReason]),
+    Print(Prefix ++ "An exception was raised: ~w:~p.~n", [ExcKind,ExcReason]),
     Print(Prefix ++ "Stacktrace: ~p.~n", [StackTrace]);
 report_fail_reason({sub_props,SubReasons}, Prefix, Print) ->
     Report =


### PR DESCRIPTION
When printing out (e.g. exception reasons), `proper` often uses the `~w` control sequence. `~p` could be considered as a better alternative.

From the docs:

`~w`
> Writes data with the standard syntax. This is used to output Erlang terms. Atoms are printed within quotes if they contain embedded non-printable characters. Atom characters > 255 are escaped unless the Unicode translation modifier (t) is used. Floats are printed accurately as the shortest, correctly rounded string.

`~p`
> Writes the data with standard syntax in the same way as ~w, but breaks terms whose printed representation is longer than one line into many lines and indents each line sensibly. Left-justification is not supported. It also tries to detect flat lists of printable characters and output these as strings.

From my experience interacting with `proper`, the latter would provide a more readable output in many cases. For example, given the following test:

```
-module(prop_exc).

-include_lib("proper/include/proper.hrl").
-include_lib("stdlib/include/assert.hrl").

prop_main() ->
  ?FORALL(B, boolean(), check(B)).

check(B) ->
  ?assertEqual(true, B),
  true.
```

The current version of `proper` would result in:

```
1> proper:quickcheck(prop_exc:prop_main()).
.!
Failed: After 2 test(s).
An exception was raised: error:{assertEqual,[{module,prop_exc},{line,10},{expression,[66]},{expected,true},{value,false}]}.
Stacktrace: [{prop_exc,'-check/1-fun-0-',1,
                       [{file,"test/prop_exc.erl"},{line,10}]},
             {prop_exc,check,1,[{file,"test/prop_exc.erl"},{line,10}]}].
false
```

Whilst the version patched with this PR would result in:

```
1> proper:quickcheck(prop_exc:prop_main()).
..!
Failed: After 3 test(s).
An exception was raised: error:{assertEqual,
                                   [{module,prop_exc},
                                    {line,10},
                                    {expression,"B"},
                                    {expected,true},
                                    {value,false}]}.
Stacktrace: [{prop_exc,'-check/1-fun-0-',1,
                       [{file,"test/prop_exc.erl"},{line,10}]},
             {prop_exc,check,1,[{file,"test/prop_exc.erl"},{line,10}]}].
false
```

Notice both the value of the variable printed (`[66]` vs `"B"`) and the line breaks.

There are other places in the `proper` code base which could potentially benefit from similar changes, but I wanted to only propose a single one, in case you have a reason to avoid pretty-printing.