### PR TITLE
Convert targeted to proper interface

### DIFF
--- a/include/proper_common.hrl
+++ b/include/proper_common.hrl
@@ -35,7 +35,7 @@
 -define(EXISTS(X,RawType,Prop), proper:exists(RawType, fun(X) -> Prop end, false)).
 -define(NOT_EXISTS(X,RawType,Prop), proper:exists(RawType, fun(X) -> Prop end, true)).
 -define(FORALL_TARGETED(X, RawType, Prop),
-        proper:exists(RawType, fun(X) -> not Prop end, true)).
+        proper:targeted(RawType, fun(X) -> Prop end)).
 -define(IMPLIES(Pre,Prop), proper:implies(Pre,?DELAY(Prop))).
 -define(WHENFAIL(Action,Prop), proper:whenfail(?DELAY(Action),?DELAY(Prop))).
 -define(TRAPEXIT(Prop), proper:trapexit(?DELAY(Prop))).

--- a/src/proper.erl
+++ b/src/proper.erl
@@ -387,7 +387,7 @@
 -export([get_size/1, global_state_init_size/1,
 	 global_state_init_size_seed/2, report_error/2]).
 -export([pure_check/1, pure_check/2]).
--export([forall/2, exists/3, implies/2, whenfail/2, trapexit/1, timeout/2, setup/2]).
+-export([forall/2, targeted/2, exists/3, implies/2, whenfail/2, trapexit/1, timeout/2, setup/2]).
 
 -export_type([test/0, outer_test/0, counterexample/0, exception/0,
 	      false_positive_mfas/0, setup_opts/0]).
@@ -445,12 +445,15 @@
 		      | {'setup', setup_fun(), outer_test()}
 		      | {'numtests', pos_integer(), outer_test()}
 		      | {'on_output', output_fun(), outer_test()}.
+-type targeted_type() :: 'none'
+                       | proper_types:type().
 %% TODO: Should the tags be of the form '$...'?
 %% @type test(). A testable property that has not been wrapped with an
 %% <a href="#external-wrappers">external wrapper</a>.
 -opaque test() :: boolean()
 	        | {'forall', proper_types:raw_type(), dependent_test()}
 	        | {'exists', proper_target:tmap(), dependent_test(), boolean()}
+            | {'targeted', proper_target:tmap(), targeted_type(), dependent_test()}
 	        | {'conjunction', [{tag(),test()}]}
 	        | {'implies', boolean(), delayed_test()}
 	        | {'sample', sample(), stats_printer(), test()}
@@ -999,6 +1002,11 @@ forall(RawType, DTest) ->
 -spec exists(proper_types:raw_type(), dependent_test(), boolean()) -> test().
 exists(RawType, DTest, Not) ->
     {exists, #{gen => RawType}, DTest, Not}.
+
+%% @private
+-spec targeted(proper_types:raw_type(), dependent_test()) -> test().
+targeted(RawType, DTest) ->
+    {targeted, #{gen => RawType}, none, DTest}.
 
 %% @doc Returns a property that is true only if all of the sub-properties
 %% `SubProps' are true. Each sub-property should be tagged with a distinct atom.

--- a/src/proper.erl
+++ b/src/proper.erl
@@ -959,6 +959,8 @@ peel_test({setup,Fun,OuterTest}, #opts{setup_funs = Funs} = Opts) ->
     peel_test(OuterTest, Opts#opts{setup_funs = [Fun|Funs]});
 peel_test({exists,_,_,_} = ExistsTest, Opts) ->
     {ExistsTest, Opts#opts{numtests=1}};
+peel_test({targeted, _, _, _} = TargetedTest, #opts{numtests = NumTests} = Opts) ->
+    {TargetedTest, Opts#opts{search_steps = NumTests}};
 peel_test(Test, Opts) ->
     {Test, Opts}.
 

--- a/src/proper.erl
+++ b/src/proper.erl
@@ -1227,6 +1227,13 @@ get_rerun_result({error,_Reason} = ErrorResult) ->
     ErrorResult.
 
 -spec perform(pos_integer(), test(), opts()) -> imm_result().
+perform(NumTests, {targeted, TMap, _Target, Prop}, #opts{search_strategy = Strat} = Opts) ->
+    proper_target:init_strategy(Strat),
+    Target = proper_target:targeted(make_ref(), TMap),
+    Res = perform(0, NumTests, ?MAX_TRIES_FACTOR * NumTests,
+                  {targeted, TMap, Target, Prop}, none, none, Opts),
+    proper_target:cleanup_strategy(),
+    Res;
 perform(NumTests, Test, Opts) ->
     perform(0, NumTests, ?MAX_TRIES_FACTOR * NumTests, Test, none, none, Opts).
 

--- a/src/proper.erl
+++ b/src/proper.erl
@@ -1897,6 +1897,10 @@ skip_to_next({exists, TMap, Prop, false}) ->
     Type = proper_types:cook_outer(RawType),
     %% negate the property result around for ?NOT_EXISTS
     {Type, fun (X) -> not Prop(X) end};
+skip_to_next({targeted, TMap, _Target, Prop}) ->
+    RawType = proper_target:get_shrinker(TMap),
+    Type = proper_types:cook_outer(RawType),
+    {Type, Prop};
 skip_to_next({forall,RawType,Prop}) ->
     Type = proper_types:cook_outer(RawType),
     {Type, Prop};


### PR DESCRIPTION
This pull request was done with 2 problems in mind:

1. Working to implement the Stateful TPBT of PropEr, I came across a problem with `?FORALL_TARGETED`, which turned out to come from not accepting `?TRAPEXIT` as a valid test. The problem was caused by [this line of code](https://github.com/proper-testing/proper/blob/3d74fde55450609bf11ba37bb28835375a2a5708/include/proper_common.hrl#L38), which does not accept any "non-immediate" boolean properties.
2. When calling the `?FORALL_TARGETED` macro, the messages after passing or failing are not in line with the rest of the PropEr interface, that is what was printed was always that the tests passed or failed "After 1 test(s).".

The changes made to the code, do not have any big implications on the `?FORALL_TARGETED` functionality, rather aim to fix the problems stated above. That is, `?FORALL_TARGETED` now is executing the number of tests defined by `numtests` and accepts "non-immediate" boolean properties.