### PR TITLE
Remove conditional support for Erlang/OTP versions prior to 19.x

### DIFF
--- a/include/proper_internal.hrl
+++ b/include/proper_internal.hrl
@@ -33,25 +33,14 @@
 %% Random generator selection
 %%------------------------------------------------------------------------------
 
--ifdef(AT_LEAST_19).
--define(RANDOM_MOD, rand).   %% for 19.x onwards use the 'rand' module
+-define(RANDOM_MOD, rand).
 -define(SEED_NAME, rand_seed).
--else.
--define(RANDOM_MOD, random).
--define(SEED_NAME, random_seed).
--endif.
-
 
 %%------------------------------------------------------------------------------
 %% Line annotations
 %%------------------------------------------------------------------------------
 
--ifdef(AT_LEAST_19).
 -define(anno(L), erl_anno:new(L)).
--else.
--define(anno(L), L).
--endif.
-
 
 %%------------------------------------------------------------------------------
 %% Stacktrace access
@@ -103,11 +92,7 @@
 -type abs_expr()   :: erl_parse:abstract_expr().
 -type abs_clause() :: erl_parse:abstract_clause().
 
--ifdef(AT_LEAST_19).
--type abs_type() :: erl_parse:abstract_type().
--else.
--type abs_type() :: term().
--endif.
+-type abs_type()   :: erl_parse:abstract_type().
 %% TODO: Replace abs_rec_field with its proper type once it is exported.
 -type abs_rec_field() :: term().	% erl_parse:af_field_decl().
 

--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 %%% -*- coding: utf-8 -*-
 %%% -*- erlang-indent-level: 2 -*-
 %%% -------------------------------------------------------------------
-%%% Copyright 2010-2016 Manolis Papadakis <manopapad@gmail.com>,
+%%% Copyright 2010-2019 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>
 %%%
@@ -38,7 +38,6 @@
 	    report_warnings, {warn_format,1}, warn_export_vars,
 	    warn_obsolete_guard, warn_unused_import,
 	    warn_missing_spec, warn_untyped_record,
-	    {platform_define, "^19|^2", 'AT_LEAST_19'},
 	    {platform_define, "^2", 'AT_LEAST_20'},
 	    {platform_define, "^2[1-9]", 'AT_LEAST_21'}]}.
 

--- a/src/proper.erl
+++ b/src/proper.erl
@@ -1,7 +1,7 @@
 %%% -*- coding: utf-8 -*-
 %%% -*- erlang-indent-level: 2 -*-
 %%% -------------------------------------------------------------------
-%%% Copyright 2010-2018 Manolis Papadakis <manopapad@gmail.com>,
+%%% Copyright 2010-2019 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>,
 %%%                     Kostis Sagonas <kostis@cs.ntua.gr>,
 %%%                 and Andreas Löscher <andreas.loscher@it.uu.se>
@@ -21,7 +21,7 @@
 %%% You should have received a copy of the GNU General Public License
 %%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
 
-%%% @copyright 2010-2018 Manolis Papadakis, Eirini Arvaniti, Kostis Sagonas and Andreas Löscher
+%%% @copyright 2010-2019 Manolis Papadakis, Eirini Arvaniti, Kostis Sagonas and Andreas Löscher
 %%% @version {@version}
 %%% @author Manolis Papadakis
 
@@ -530,16 +530,12 @@
 	      printers = []  :: [stats_printer()]}).
 -type ctx() :: #ctx{}.
 
--ifdef(AT_LEAST_19).
 -type setup_opts() :: #{numtests := pos_integer(),
 			search_steps := pos_integer(),
 			search_strategy := atom(),
 			start_size := size(),
 			max_size := size(),
 			output_fun := output_fun()}.
--else.
--type setup_opts() :: term().
--endif.
 %%
 
 %%-----------------------------------------------------------------------------

--- a/src/proper_arith.erl
+++ b/src/proper_arith.erl
@@ -224,16 +224,9 @@ remove_n(N, {List,Acc}) ->
 %% @doc Seeds the random number generator. This function should be run before
 %% calling any random function from this module.
 -spec rand_start(seed()) -> 'ok'.
--ifdef(AT_LEAST_19).
 rand_start(Seed) ->
     _ = rand:seed(exsplus, Seed),
     ok.
--else.
-rand_start(Seed) ->
-    _ = ?RANDOM_MOD:seed(Seed),
-    %% TODO: read option for RNG bijections here
-    ok.
--endif.
 
 %% @doc Conditionally seeds the random number generator. This function should
 %% be run before calling any random function from this module.
@@ -247,17 +240,9 @@ rand_restart(Seed) ->
     end.
 
 -spec rand_reseed() -> 'ok'.
--ifdef(AT_LEAST_19).
 rand_reseed() ->
     _ = rand:seed(exsplus, os:timestamp()),
     ok.
--else.
-rand_reseed() ->
-    %% TODO: This should use the pid of the process somehow, in case two
-    %%       spawned functions call it simultaneously?
-    _ = ?RANDOM_MOD:seed(os:timestamp()),
-    ok.
--endif.
 
 -spec rand_stop() -> 'ok'.
 rand_stop() ->

--- a/src/proper_gen.erl
+++ b/src/proper_gen.erl
@@ -632,11 +632,6 @@ function_body(Args, RetType, {Seed1,Seed2}) ->
 	    proper_symb:internal_eval(Ret)
     end.
 
--ifdef(AT_LEAST_19).
 update_seed(Seed) ->
     _ = rand:seed(exsplus, Seed),
     ok.
--else.
-update_seed(Seed) ->
-    put(?SEED_NAME, Seed).
--endif.

--- a/src/proper_gen_next.erl
+++ b/src/proper_gen_next.erl
@@ -1,7 +1,7 @@
 %%% -*- coding: utf-8 -*-
 %%% -*- erlang-indent-level: 2 -*-
 %%% -------------------------------------------------------------------
-%%% Copyright (c) 2017-2018, Andreas Löscher <andreas.loscher@it.uu.se>
+%%% Copyright (c) 2017-2019, Andreas Löscher <andreas.loscher@it.uu.se>
 %%%                     and  Kostis Sagonas <kostis@it.uu.se>
 %%%
 %%% This file is part of PropEr.
@@ -19,7 +19,7 @@
 %%% You should have received a copy of the GNU General Public License
 %%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
 
-%%% @copyright 2017-2018 Andreas Löscher and Kostis Sagonas
+%%% @copyright 2017-2019 Andreas Löscher and Kostis Sagonas
 %%% @version {@version}
 %%% @author Andreas Löscher
 
@@ -34,11 +34,7 @@
 
 -include("proper_internal.hrl").
 
--ifdef(AT_LEAST_19).
 -dialyzer({no_improper_lists, construct_improper/2}).
--else.
--export([construct_improper/2]).
--endif.
 
 -define(GENERATORS, [{fun is_user_defined/1, fun user_defined_gen_sa/1}, %% needs to be first!
                      {fun is_atom/1, fun dont_change/1},
@@ -725,9 +721,6 @@ safe_zip(ITL, ITR, Acc) ->
     _ -> {ok, construct_improper(Acc, {ITL, ITR})}
   end.
 
--ifndef(AT_LEAST_19).
--spec construct_improper(list(), term()) -> term().
--endif.
 construct_improper([], IT) ->
   IT;
 construct_improper([H|T], IT) ->


### PR DESCRIPTION
The code base contained various ifdefs for conditional compilation
using an Erlang/OTP prior to 19.0; e.g., using  the `random` instead
of the `rand` module and all that code most likely still worked.

However, our `rebar.config` insisted that `{minimum_otp_vsn, "19.0"}`
and also this conditional compilation also caused warnings to some
Elixir projects that compiled using `mix`; see #204.

Although these latter problems could be fixed also by switching to
`rebar3`, there is very little reason these days to have code around
which is not tested and may or may not still support old Erlang/OTP
releases.  Making the use of the `rand` module unconditional, also
shuts off, as a (bonus?) side-effect, the warnings for the `random`
module being deprecated.