### PR TITLE
Cleanup Targeted Implementation

### DIFF
--- a/include/proper_common.hrl
+++ b/include/proper_common.hrl
@@ -75,7 +75,7 @@
 %% Macros for backwards compatibility
 %%------------------------------------------------------------------------------
 
--define(TARGET(TMap), proper_target:targeted(make_ref(), TMap)).
+-define(TARGET(TMap), proper_target:targeted(TMap)).
 -define(STRATEGY(Strat, Prop), ?SETUP(fun (Opts) ->
                                           proper_target:use_strategy(Strat, Opts),
                                           fun proper_target:cleanup_strategy/0

--- a/src/proper.erl
+++ b/src/proper.erl
@@ -1227,7 +1227,7 @@ get_rerun_result({error,_Reason} = ErrorResult) ->
 -spec perform(pos_integer(), test(), opts()) -> imm_result().
 perform(NumTests, {targeted, TMap, _Target, Prop}, #opts{search_strategy = Strat} = Opts) ->
     proper_target:init_strategy(Strat),
-    Target = proper_target:targeted(make_ref(), TMap),
+    Target = proper_target:targeted(TMap),
     Res = perform(0, NumTests, ?MAX_TRIES_FACTOR * NumTests,
                   {targeted, TMap, Target, Prop}, none, none, Opts),
     proper_target:cleanup_strategy(),
@@ -1375,7 +1375,7 @@ run({exists, TMap, Prop, Not}, #ctx{mode = new} = Ctx,
     #opts{search_strategy = Strat, search_steps = Steps,
           output_fun = Print, start_size = StartSize} = Opts) ->
     proper_target:init_strategy(Strat),
-    Target = proper_target:targeted(make_ref(), TMap),
+    Target = proper_target:targeted(TMap),
     Print("[", []),
     BackupSize = get('$size'),
     put('$size', StartSize - 1),


### PR DESCRIPTION
This PR is intended to remove some code in the `proper_sa` implementation, where the `state` was represented as a `dict`. However, after checking all the tests, as well as the examples, it seemed that this `dict` is always of size 1, hence its existence is not necessary.

This change should also act as an optimization to the `targeted` implementation, as there is no more iteration of the `dict`.