### PR TITLE
Add rebar3-hex plugin

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -45,3 +45,5 @@
 
 {dialyzer, [{warnings, [unmatched_returns]},
             {plt_extra_apps, [erts, kernel, stdlib, compiler, crypto, syntax_tools]}]}.
+
+{plugins, [rebar3_hex]}.


### PR DESCRIPTION
This pull request is a follow-up to #211 and https://github.com/alfert/propcheck/issues/121. The pull request adds the [rebar3_hex](https://github.com/tsloughter/rebar3_hex) plugin to allow publishing to hex.pm.  If the user is already registered with hex.pm, publishing boils down to two steps:

* `rebar3 hex user auth` (authenticate with hex.pm)
* `rebar3 hex publish` (publish to public hex.pm)

Note that compiling with `rebar` from the repository itself results in a warning, but the build completes:

```
./rebar compile
WARN:  Missing plugins: [rebar3_hex]
==> proper (compile)
...
```

@kostis Can you CC the people responsible for publishing to hex.pm? I tried the plugin using a small example project, but did not dare to try `rebar3 hex publish` within PropEr itself.