### PR TITLE
Refactor proper_internal types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ otp_release:
    - 20.3
    - 20.0
    - 19.3
-   - 19.0
+   - 19.1
 
 # coverage tests
 jobs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ otp_release:
    - 20.3
    - 20.0
    - 19.3
-   - 19.1
 
 # coverage tests
 jobs:

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ incompatibilities between the two tools by now.
 <!-- Badges (alphabetically) -->
 [codecov badge]: https://codecov.io/gh/proper-testing/proper/branch/master/graph/badge.svg
 [commit badge]: https://img.shields.io/github/last-commit/proper-testing/proper.svg?style=flat-square
-[erlang versions badge]: https://img.shields.io/badge/erlang-19.0%20to%2022.3-blue.svg?style=flat-square
+[erlang versions badge]: https://img.shields.io/badge/erlang-19.1%20to%2022.3-blue.svg?style=flat-square
 [license badge]: https://img.shields.io/github/license/proper-testing/proper.svg?style=flat-square
 [release badge]: https://img.shields.io/github/release/proper-testing/proper.svg?style=flat-square
 [travis badge]: https://img.shields.io/travis/proper-testing/proper/master.svg?style=flat-square

--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ incompatibilities between the two tools by now.
 <!-- Badges (alphabetically) -->
 [codecov badge]: https://codecov.io/gh/proper-testing/proper/branch/master/graph/badge.svg
 [commit badge]: https://img.shields.io/github/last-commit/proper-testing/proper.svg?style=flat-square
-[erlang versions badge]: https://img.shields.io/badge/erlang-19.1%20to%2022.3-blue.svg?style=flat-square
+[erlang versions badge]: https://img.shields.io/badge/erlang-19.0%20to%2022.3-blue.svg?style=flat-square
 [license badge]: https://img.shields.io/github/license/proper-testing/proper.svg?style=flat-square
 [release badge]: https://img.shields.io/github/release/proper-testing/proper.svg?style=flat-square
 [travis badge]: https://img.shields.io/travis/proper-testing/proper/master.svg?style=flat-square

--- a/include/proper_common.hrl
+++ b/include/proper_common.hrl
@@ -63,7 +63,7 @@
         proper_types:add_constraint(RawType,fun(X) -> Condition end,false)).
 
 %%------------------------------------------------------------------------------
-%% Target macros
+%% Targeted macros
 %%------------------------------------------------------------------------------
 
 -define(MAXIMIZE(Fitness), proper_target:update_uv(Fitness, inf)).

--- a/include/proper_internal.hrl
+++ b/include/proper_internal.hrl
@@ -83,7 +83,6 @@
 -type mod_name() :: atom().
 -type fun_name() :: atom().
 -type size() :: non_neg_integer().
--type length() :: non_neg_integer().
 -type position() :: pos_integer().
 
 -type abs_form()   :: erl_parse:abstract_form().

--- a/include/proper_internal.hrl
+++ b/include/proper_internal.hrl
@@ -82,7 +82,6 @@
 %% TODO: Perhaps these should be moved inside modules.
 -type mod_name() :: atom().
 -type fun_name() :: atom().
--type size() :: non_neg_integer().
 -type position() :: pos_integer().
 
 -type abs_form()   :: erl_parse:abstract_form().

--- a/include/proper_internal.hrl
+++ b/include/proper_internal.hrl
@@ -1,7 +1,7 @@
 %%% -*- coding: utf-8 -*-
 %%% -*- erlang-indent-level: 2 -*-
 %%% -------------------------------------------------------------------
-%%% Copyright 2010-2019 Manolis Papadakis <manopapad@gmail.com>,
+%%% Copyright 2010-2020 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>
 %%%
@@ -20,7 +20,7 @@
 %%% You should have received a copy of the GNU General Public License
 %%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
 
-%%% @copyright 2010-2019 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
+%%% @copyright 2010-2020 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
 %%% @version {@version}
 %%% @author Manolis Papadakis
 %%% @doc Internal header file: This header is included in all PropEr source
@@ -85,7 +85,6 @@
 -type size() :: non_neg_integer().
 -type length() :: non_neg_integer().
 -type position() :: pos_integer().
--type frequency() :: pos_integer().
 -type seed() :: {non_neg_integer(), non_neg_integer(), non_neg_integer()}.
 
 -type abs_form()   :: erl_parse:abstract_form().

--- a/include/proper_internal.hrl
+++ b/include/proper_internal.hrl
@@ -85,7 +85,6 @@
 -type size() :: non_neg_integer().
 -type length() :: non_neg_integer().
 -type position() :: pos_integer().
--type seed() :: {non_neg_integer(), non_neg_integer(), non_neg_integer()}.
 
 -type abs_form()   :: erl_parse:abstract_form().
 -type abs_expr()   :: erl_parse:abstract_expr().

--- a/src/proper.erl
+++ b/src/proper.erl
@@ -420,7 +420,7 @@
 -type sub_counterexamples() :: [{tag(),counterexample()}].
 
 -type sample() :: [term()].
--type freq_sample() :: [{term(),frequency()}].
+-type freq_sample() :: [{term(),proper_types:frequency()}].
 -type side_effects_fun() :: fun(() -> 'ok').
 -type fail_actions() :: [side_effects_fun()].
 -type output_fun() :: fun((string(),[term()]) -> 'ok').
@@ -2178,7 +2178,8 @@ get_freqs([Term | Rest], Freqs) ->
     {Freq,Others} = remove_all(Term, 1, Rest),
     get_freqs(Others, [{Term,Freq} | Freqs]).
 
--spec remove_all(term(), frequency(), sample()) -> {frequency(), sample()}.
+-spec remove_all(term(), proper_types:frequency(), sample()) ->
+	  {proper_types:frequency(), sample()}.
 remove_all(X, Freq, [X | Rest]) ->
     remove_all(X, Freq + 1, Rest);
 remove_all(_X, Freq, Sample) ->

--- a/src/proper.erl
+++ b/src/proper.erl
@@ -453,7 +453,7 @@
 -opaque test() :: boolean()
 	        | {'forall', proper_types:raw_type(), dependent_test()}
 	        | {'exists', proper_target:tmap(), dependent_test(), boolean()}
-            | {'targeted', proper_target:tmap(), targeted_type(), dependent_test()}
+                | {'targeted', proper_target:tmap(), targeted_type(), dependent_test()}
 	        | {'conjunction', [{tag(),test()}]}
 	        | {'implies', boolean(), delayed_test()}
 	        | {'sample', sample(), stats_printer(), test()}
@@ -489,10 +489,10 @@
 		  | 'long_result'
 		  | {'numtests',pos_integer()}
 		  | {'search_steps',pos_integer()}
-		  | {'search_strategy', atom()}
+		  | {'search_strategy',atom()}
 		  | pos_integer()
-		  | {'start_size',size()}
-		  | {'max_size',size()}
+		  | {'start_size',proper_gen:size()}
+		  | {'max_size',proper_gen:size()}
 		  | {'max_shrinks',non_neg_integer()}
 		  | 'noshrink'
 		  | {'constraint_tries',pos_integer()}
@@ -509,9 +509,9 @@
 	       numtests         = 100             :: pos_integer(),
 	       search_steps     = 1000            :: pos_integer(),
 	       search_strategy  = proper_sa       :: atom(),
-	       start_size       = 1               :: size(),
+	       start_size       = 1               :: proper_gen:size(),
 	       seed             = os:timestamp()  :: proper_gen:seed(),
-	       max_size         = 42              :: size(),
+	       max_size         = 42              :: proper_gem:size(),
 	       max_shrinks      = 500             :: non_neg_integer(),
 	       noshrink         = false           :: boolean(),
 	       constraint_tries = 50              :: pos_integer(),
@@ -533,10 +533,9 @@
 -type setup_opts() :: #{numtests := pos_integer(),
 			search_steps := pos_integer(),
 			search_strategy := atom(),
-			start_size := size(),
-			max_size := size(),
+			start_size := proper_gen:size(),
+			max_size := proper_gen:size(),
 			output_fun := output_fun()}.
-%%
 
 %%-----------------------------------------------------------------------------
 %% Result types
@@ -606,7 +605,8 @@ grow_size(#opts{max_size = MaxSize} = Opts) ->
 	    ok
     end.
 
--spec tests_at_next_size(size(), opts()) -> {pos_integer(), size()}.
+-spec tests_at_next_size(proper_gen:size(), opts()) ->
+	  {pos_integer(), proper_gen:size()}.
 tests_at_next_size(_Size, #opts{numtests = 1, start_size = StartSize}) ->
     {1, StartSize};
 tests_at_next_size(Size, #opts{numtests = NumTests, start_size = StartSize,
@@ -637,7 +637,7 @@ tests_at_next_size(Size, #opts{numtests = NumTests, start_size = StartSize,
     end.
 
 %% @private
--spec get_size(proper_types:type()) -> size() | 'undefined'.
+-spec get_size(proper_types:type()) -> proper_gen:size() | 'undefined'.
 get_size(Type) ->
     case get('$size') of
 	undefined ->
@@ -650,12 +650,12 @@ get_size(Type) ->
     end.
 
 %% @private
--spec global_state_init_size(size()) -> 'ok'.
+-spec global_state_init_size(proper_gen:size()) -> 'ok'.
 global_state_init_size(Size) ->
     global_state_init(#opts{start_size = Size}).
 
 %% @private
--spec global_state_init_size_seed(size(), proper_gen:seed()) -> 'ok'.
+-spec global_state_init_size_seed(proper_gen:size(), proper_gen:seed()) -> 'ok'.
 global_state_init_size_seed(Size, Seed) ->
     global_state_init(#opts{start_size = Size, seed = Seed}).
 
@@ -1334,7 +1334,8 @@ add_samples(MoreSamples, Samples) ->
 
 
 %% Evaluated only for its side-effects.
--spec gen_and_print_samples(proper_types:raw_type(), size(), size()) -> 'ok'.
+-spec gen_and_print_samples(proper_types:raw_type(),
+			    proper_gen:size(), proper_gen:size()) -> 'ok'.
 gen_and_print_samples(RawType, StartSize, EndSize) ->
     Tests = EndSize - StartSize + 1,
     Prop = ?FORALL(X, RawType, begin io:format("~p~n",[X]), true end),

--- a/src/proper.erl
+++ b/src/proper.erl
@@ -510,7 +510,7 @@
 	       search_steps     = 1000            :: pos_integer(),
 	       search_strategy  = proper_sa       :: atom(),
 	       start_size       = 1               :: size(),
-	       seed             = os:timestamp()  :: seed(),
+	       seed             = os:timestamp()  :: proper_gen:seed(),
 	       max_size         = 42              :: size(),
 	       max_shrinks      = 500             :: non_neg_integer(),
 	       noshrink         = false           :: boolean(),
@@ -655,7 +655,7 @@ global_state_init_size(Size) ->
     global_state_init(#opts{start_size = Size}).
 
 %% @private
--spec global_state_init_size_seed(size(), seed()) -> 'ok'.
+-spec global_state_init_size_seed(size(), proper_gen:seed()) -> 'ok'.
 global_state_init_size_seed(Size, Seed) ->
     global_state_init(#opts{start_size = Size, seed = Seed}).
 

--- a/src/proper.erl
+++ b/src/proper.erl
@@ -489,7 +489,7 @@
 		  | 'long_result'
 		  | {'numtests',pos_integer()}
 		  | {'search_steps',pos_integer()}
-		  | {'search_strategy',atom()}
+		  | {'search_strategy',proper_target:strategy()}
 		  | pos_integer()
 		  | {'start_size',proper_gen:size()}
 		  | {'max_size',proper_gen:size()}
@@ -508,10 +508,10 @@
 	       long_result      = false           :: boolean(),
 	       numtests         = 100             :: pos_integer(),
 	       search_steps     = 1000            :: pos_integer(),
-	       search_strategy  = proper_sa       :: atom(),
+	       search_strategy  = proper_sa       :: proper_target:strategy(),
 	       start_size       = 1               :: proper_gen:size(),
 	       seed             = os:timestamp()  :: proper_gen:seed(),
-	       max_size         = 42              :: proper_gem:size(),
+	       max_size         = 42              :: proper_gen:size(),
 	       max_shrinks      = 500             :: non_neg_integer(),
 	       noshrink         = false           :: boolean(),
 	       constraint_tries = 50              :: pos_integer(),
@@ -532,7 +532,7 @@
 
 -type setup_opts() :: #{numtests := pos_integer(),
 			search_steps := pos_integer(),
-			search_strategy := atom(),
+			search_strategy := proper_target:strategy(),
 			start_size := proper_gen:size(),
 			max_size := proper_gen:size(),
 			output_fun := output_fun()}.

--- a/src/proper_arith.erl
+++ b/src/proper_arith.erl
@@ -1,7 +1,7 @@
 %%% -*- coding: utf-8 -*-
 %%% -*- erlang-indent-level: 2 -*-
 %%% -------------------------------------------------------------------
-%%% Copyright 2010-2016 Manolis Papadakis <manopapad@gmail.com>,
+%%% Copyright 2010-2020 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>
 %%%
@@ -20,7 +20,7 @@
 %%% You should have received a copy of the GNU General Public License
 %%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
 
-%%% @copyright 2010-2016 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
+%%% @copyright 2010-2020 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
 %%% @version {@version}
 %%% @author Manolis Papadakis
 %%% @doc This module contains helper arithmetic, list handling and random
@@ -258,7 +258,7 @@ rand_non_neg_int(Const) ->
     trunc(rand_non_neg_float(Const)).
 
 -spec bounded_rand_non_neg_int(non_neg_integer(), non_neg_integer()) ->
-				      non_neg_integer().
+	  non_neg_integer().
 bounded_rand_non_neg_int(Const, Lim) when is_integer(Lim), Lim >= 0 ->
     X = rand_non_neg_int(Const),
     case X > Lim of
@@ -280,7 +280,7 @@ smart_rand_int(Const, Low, High) ->
     end.
 
 -spec wide_range_rand_int(non_neg_integer(), integer(), integer()) ->
-				 integer().
+	  integer().
 wide_range_rand_int(Const, Low, High) when Low >= 0 ->
     Low + bounded_rand_non_neg_int(Const, High - Low);
 wide_range_rand_int(Const, Low, High) when High =< 0 ->
@@ -343,13 +343,14 @@ rand_choose(Choices) when Choices =/= [] ->
     Pos = rand_int(1, length(Choices)),
     {Pos, lists:nth(Pos, Choices)}.
 
--spec freq_choose([{frequency(),T},...]) -> {position(),T}.
+-spec freq_choose([{proper_types:frequency(),T},...]) -> {position(),T}.
 freq_choose(Choices) when Choices =/= []  ->
     AddFreq = fun({Freq,_},Acc) -> Freq + Acc end,
     SumFreq = lists:foldl(AddFreq, 0, Choices),
     freq_select(rand_int(1, SumFreq), Choices, 1).
 
--spec freq_select(frequency(), [{frequency(),T}], position()) -> {position(),T}.
+-spec freq_select(proper_types:frequency(), [{proper_types:frequency(),T}],
+		  position()) -> {position(),T}.
 freq_select(N, [{Freq,Choice} | Rest], Pos) ->
     case N =< Freq of
 	true ->

--- a/src/proper_arith.erl
+++ b/src/proper_arith.erl
@@ -223,14 +223,14 @@ remove_n(N, {List,Acc}) ->
 
 %% @doc Seeds the random number generator. This function should be run before
 %% calling any random function from this module.
--spec rand_start(seed()) -> 'ok'.
+-spec rand_start(proper_gen:seed()) -> 'ok'.
 rand_start(Seed) ->
     _ = rand:seed(exsplus, Seed),
     ok.
 
 %% @doc Conditionally seeds the random number generator. This function should
 %% be run before calling any random function from this module.
--spec rand_restart(seed()) -> 'ok'.
+-spec rand_restart(proper_gen:seed()) -> 'ok'.
 rand_restart(Seed) ->
     case get(?SEED_NAME) of
         undefined ->

--- a/src/proper_arith.erl
+++ b/src/proper_arith.erl
@@ -206,7 +206,7 @@ insert_tr([X | XsTail], [Pos | PosTail], Ys, Pos, Acc) ->
 insert_tr(Xs, Positions, [Y | YsTail], Pos, Acc) ->
     insert_tr(Xs, Positions, YsTail, Pos + 1, [Y | Acc]).
 
--spec unflatten([T], [length()]) -> [[T]].
+-spec unflatten([T], [proper_types:length()]) -> [[T]].
 unflatten(List, Lens) ->
     {[],RevSubLists} = lists:foldl(fun remove_n/2, {List,[]}, Lens),
     lists:reverse(RevSubLists).

--- a/src/proper_gen.erl
+++ b/src/proper_gen.erl
@@ -1,7 +1,7 @@
 %%% -*- coding: utf-8 -*-
 %%% -*- erlang-indent-level: 2 -*-
 %%% -------------------------------------------------------------------
-%%% Copyright 2010-2019 Manolis Papadakis <manopapad@gmail.com>,
+%%% Copyright 2010-2020 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>
 %%%
@@ -20,7 +20,7 @@
 %%% You should have received a copy of the GNU General Public License
 %%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
 
-%%% @copyright 2010-2019 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
+%%% @copyright 2010-2020 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
 %%% @version {@version}
 %%% @author Manolis Papadakis
 
@@ -103,6 +103,8 @@
 -type alt_gens() :: fun(() -> [imm_instance()]).
 %% @private_type
 -type fun_seed() :: {non_neg_integer(),non_neg_integer()}.
+%% @private_type
+-type freq_choices() :: [{proper_types:frequency(),proper_types:type()},...].
 
 
 %%-----------------------------------------------------------------------------
@@ -485,8 +487,7 @@ union_gen(Choices) ->
     generate(Type).
 
 %% @private
--spec weighted_union_gen([{frequency(),proper_types:type()},...]) ->
-	  imm_instance().
+-spec weighted_union_gen(freq_choices()) -> imm_instance().
 weighted_union_gen(FreqChoices) ->
     {_Choice,Type} = proper_arith:freq_choose(FreqChoices),
     generate(Type).
@@ -502,8 +503,7 @@ safe_union_gen(Choices) ->
     end.
 
 %% @private
--spec safe_weighted_union_gen([{frequency(),proper_types:type()},...]) ->
-         imm_instance().
+-spec safe_weighted_union_gen(freq_choices()) -> imm_instance().
 safe_weighted_union_gen(FreqChoices) ->
     {Choice,Type} = proper_arith:freq_choose(FreqChoices),
     try generate(Type)

--- a/src/proper_gen.erl
+++ b/src/proper_gen.erl
@@ -48,7 +48,7 @@
 	 safe_union_gen/1]).
 
 %% Public API types
--export_type([instance/0, seed/0]).
+-export_type([instance/0, seed/0, size/0]).
 %% Internal types
 -export_type([imm_instance/0, sized_generator/0, nosize_generator/0,
 	      generator/0, reverse_gen/0, combine_fun/0, alt_gens/0]).
@@ -62,9 +62,9 @@
 %% Types
 %%-----------------------------------------------------------------------------
 
--type seed()     :: {non_neg_integer(), non_neg_integer(), non_neg_integer()}.
-
 -type instance() :: term().
+-type seed()     :: {non_neg_integer(), non_neg_integer(), non_neg_integer()}.
+-type size()     :: non_neg_integer().
 
 %% TODO: update imm_instance() when adding more types: be careful when reading
 %%	 anything that returns it

--- a/src/proper_gen.erl
+++ b/src/proper_gen.erl
@@ -413,7 +413,7 @@ binary_rev(Binary) ->
     {'$used', binary_to_list(Binary), Binary}.
 
 %% @private
--spec binary_len_gen(length()) -> proper_types:type().
+-spec binary_len_gen(proper_types:length()) -> proper_types:type().
 binary_len_gen(Len) ->
     ?LET(Bytes,
 	 proper_types:vector(Len, proper_types:byte()),
@@ -443,7 +443,7 @@ bitstring_rev(BitString) ->
      BitString}.
 
 %% @private
--spec bitstring_len_gen(length()) -> proper_types:type().
+-spec bitstring_len_gen(proper_types:length()) -> proper_types:type().
 bitstring_len_gen(Len) ->
     BytesLen = Len div 8,
     BitsLen = Len rem 8,
@@ -475,12 +475,12 @@ distlist_gen(RawSize, Gen, NonEmpty) ->
     fixed_list_gen(InnerTypes).
 
 %% @private
--spec vector_gen(length(), proper_types:type()) -> [imm_instance()].
+-spec vector_gen(proper_types:length(), proper_types:type()) -> [imm_instance()].
 vector_gen(Len, ElemType) ->
     vector_gen_tr(Len, ElemType, []).
 
--spec vector_gen_tr(length(), proper_types:type(), [imm_instance()]) ->
-	  [imm_instance()].
+-spec vector_gen_tr(proper_types:length(), proper_types:type(),
+		    [imm_instance()]) -> [imm_instance()].
 vector_gen_tr(0, _ElemType, AccList) ->
     AccList;
 vector_gen_tr(Left, ElemType, AccList) ->

--- a/src/proper_gen.erl
+++ b/src/proper_gen.erl
@@ -47,7 +47,10 @@
 	 any_gen/1, native_type_gen/2, safe_weighted_union_gen/1,
 	 safe_union_gen/1]).
 
--export_type([instance/0, imm_instance/0, sized_generator/0, nosize_generator/0,
+%% Public API types
+-export_type([instance/0, seed/0]).
+%% Internal types
+-export_type([imm_instance/0, sized_generator/0, nosize_generator/0,
 	      generator/0, reverse_gen/0, combine_fun/0, alt_gens/0]).
 
 -include("proper_internal.hrl").
@@ -59,6 +62,10 @@
 %% Types
 %%-----------------------------------------------------------------------------
 
+-type seed()     :: {non_neg_integer(), non_neg_integer(), non_neg_integer()}.
+
+-type instance() :: term().
+
 %% TODO: update imm_instance() when adding more types: be careful when reading
 %%	 anything that returns it
 %% @private_type
@@ -66,7 +73,6 @@
 		      | instance()
 		      | {'$used', imm_instance(), imm_instance()}
 		      | {'$to_part', imm_instance()}.
--type instance() :: term().
 %% A value produced by the random instance generator.
 -type error_reason() :: 'arity_limit'
                       | {'cant_generate',[mfa()]}

--- a/src/proper_shrink.erl
+++ b/src/proper_shrink.erl
@@ -1,7 +1,7 @@
 %%% -*- coding: utf-8 -*-
 %%% -*- erlang-indent-level: 2 -*-
 %%% -------------------------------------------------------------------
-%%% Copyright 2010-2013 Manolis Papadakis <manopapad@gmail.com>,
+%%% Copyright 2010-2020 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>
 %%%
@@ -20,7 +20,7 @@
 %%% You should have received a copy of the GNU General Public License
 %%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
 
-%%% @copyright 2010-2013 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
+%%% @copyright 2010-2020 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
 %%% @version {@version}
 %%% @author Manolis Papadakis
 %%% @doc The shrinking subsystem and all predefined shrinkers are contained in
@@ -294,7 +294,7 @@ split_shrinker(Instance, Type, {shrunk,Pos,{slices,DoubleN,_Len}}) ->
     end.
 
 -spec slice(proper_gen:imm_instance(), proper_types:type(), pos_integer(),
-	    length()) ->
+	    proper_types:length()) ->
 	  {[proper_gen:imm_instance()],[proper_gen:imm_instance()]}.
 slice(Instance, Type, Slices, Len) ->
     BigSlices = Len rem Slices,
@@ -311,7 +311,7 @@ slice(Instance, Type, Slices, Len) ->
 		 || {From,SliceLen} <- WhereToSlice]).
 
 -spec take_slice(proper_gen:imm_instance(), proper_types:type(), pos_integer(),
-		 length()) ->
+		 proper_types:length()) ->
 	  {proper_gen:imm_instance(),proper_gen:imm_instance()}.
 take_slice(Instance, Type, From, SliceLen) ->
     Split = proper_types:get_prop(split, Type),

--- a/src/proper_statem.erl
+++ b/src/proper_statem.erl
@@ -1,7 +1,7 @@
 %%% -*- coding: utf-8 -*-
 %%% -*- erlang-indent-level: 2 -*-
 %%% -------------------------------------------------------------------
-%%% Copyright 2010-2018 Manolis Papadakis <manopapad@gmail.com>,
+%%% Copyright 2010-2020 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>
 %%%
@@ -20,7 +20,7 @@
 %%% You should have received a copy of the GNU General Public License
 %%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
 
-%%% @copyright 2010-2018 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
+%%% @copyright 2010-2020 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
 %%% @version {@version}
 %%% @author Eirini Arvaniti
 
@@ -229,6 +229,10 @@
 	 run_parallel_commands/3]).
 -export([state_after/2, command_names/1, zip/2]).
 
+
+-export_type([symbolic_var/0, symbolic_call/0, statem_result/0]).
+
+
 -include("proper_internal.hrl").
 
 -define(WORKERS, 2).
@@ -243,7 +247,6 @@
 -export([is_valid/4, args_defined/2]).
 -export([get_next/6, mk_first_comb/3]).
 -export([execute/3, check/6, run/3, get_initial_state/2]).
-
 
 %% -----------------------------------------------------------------------------
 %% Type declarations
@@ -272,8 +275,6 @@
 -type indices()     :: [index()].
 -type combination() :: [{pos_integer(),indices()}].
 -type lookup()      :: orddict:orddict().
-
--export_type([symbolic_var/0, symbolic_call/0, statem_result/0]).
 
 
 %% -----------------------------------------------------------------------------
@@ -334,7 +335,7 @@ commands(Mod, InitialState) ->
        is_valid(Mod, InitialState, Cmds, [])).
 
 %% @private
--spec commands(size(), mod_name(), symbolic_state(), pos_integer()) ->
+-spec commands(proper_gen:size(), mod_name(), symbolic_state(), pos_integer()) ->
          proper_types:type().
 commands(Size, Mod, State, Count) ->
     ?LAZY(

--- a/src/proper_target.erl
+++ b/src/proper_target.erl
@@ -1,8 +1,8 @@
 %%% -*- coding: utf-8 -*-
 %%% -*- erlang-indent-level: 2 -*-
 %%% -------------------------------------------------------------------
-%%% Copyright (c) 2017, Andreas Löscher <andreas.loscher@it.uu.se>
-%%%                and  Konstantinos Sagonas <kostis@it.uu.se>
+%%% Copyright (c) 2017-2020 Andreas Löscher <andreas.loscher@it.uu.se>
+%%%                     and Kostis Sagonas <kostis@it.uu.se>
 %%%
 %%% This file is part of PropEr.
 %%%
@@ -19,12 +19,12 @@
 %%% You should have received a copy of the GNU General Public License
 %%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
 
-%%% @copyright 2017 Andreas Löscher and Kostis Sagonas
+%%% @copyright 2017-2020 Andreas Löscher and Kostis Sagonas
 %%% @version {@version}
 %%% @author Andreas Löscher
 
-%%% @doc This module defines the top-level behaviour for targeted
-%%% property-based testing (TPBT). Using TPBT the input generation
+%%% @doc This module defines the top-level behaviour for Targeted
+%%% Property-Based Testing (TPBT). Using TPBT the input generation
 %%% is no longer random, but guided by a search strategy to increase
 %%% the probability of finding failing input. For this to work the user
 %%% has to specify a search strategy and also needs to extract
@@ -75,10 +75,13 @@
 -export([init_strategy/1, cleanup_strategy/0, init_target/1,
          update_uv/2, reset/0, targeted/1, get_shrinker/1]).
 
+-export_type([strategy/0]).
 
 %% -----------------------------------------------------------------------------
 %% Type declarations
 %% -----------------------------------------------------------------------------
+
+-type strategy() :: mod_name().
 
 -type fitness() :: number().
 -type tmap()    :: #{atom() => term()}.
@@ -92,7 +95,6 @@
                        | none.
 
 -type target()   :: {target_state(), next_func(), fitness_func()}.
--type strategy() :: module().
 -type opts()     :: strategy() 
                   | #{search_steps := integer(), search_strategy := strategy()}.
 

--- a/src/proper_types.erl
+++ b/src/proper_types.erl
@@ -252,7 +252,7 @@
     | {'combine', proper_gen:combine_fun()}
     | {'alt_gens', proper_gen:alt_gens()}
     | {'shrink_to_parts', boolean()}
-    | {'size_transform', fun((size()) -> size())}
+    | {'size_transform', fun((proper_gen:size()) -> proper_gen:size())}
     | {'is_instance', instance_test()}
     | {'shrinkers', [proper_shrink:shrinker()]}
     | {'noshrink', boolean()}
@@ -426,7 +426,7 @@ is_inst(Instance, RawType) ->
     is_inst(Instance, RawType, 10).
 
 %% @private
--spec is_inst(proper_gen:instance(), raw_type(), size()) ->
+-spec is_inst(proper_gen:instance(), raw_type(), proper_gen:size()) ->
 	  boolean() | {'error',{'typeserver',term()}}.
 is_inst(Instance, RawType, Size) ->
     proper:global_state_init_size(Size),
@@ -806,7 +806,7 @@ list_get_indices(_, List) ->
 %% This assumes that:
 %% - instances of size S are always valid instances of size >S
 %% - any recursive calls inside Gen are lazy
--spec distlist(size(), proper_gen:sized_generator(), boolean()) ->
+-spec distlist(proper_gen:size(), proper_gen:sized_generator(), boolean()) ->
 	  proper_types:type().
 distlist(Size, Gen, NonEmpty) ->
     ParentType = case NonEmpty of
@@ -1327,7 +1327,7 @@ weighted_default(Default, Type) ->
 %% types to produce instances that grow faster or slower, like so:
 %% ```?SIZED(Size, resize(Size * 2, list(integer()))'''
 %% The above specifies a list type that grows twice as fast as normal lists.
--spec resize(size(), Type::raw_type()) -> proper_types:type().
+-spec resize(proper_gen:size(), Type::raw_type()) -> proper_types:type().
 resize(NewSize, RawType) ->
     Type = cook_outer(RawType),
     case find_prop(size_transform, Type) of

--- a/src/proper_types.erl
+++ b/src/proper_types.erl
@@ -162,7 +162,10 @@
 	 parameter/1, parameter/2]).
 -export([le/2]).
 
--export_type([type/0, raw_type/0, extint/0, extnum/0, frequency/0]).
+%% Public API types
+-export_type([type/0, raw_type/0]).
+-export_type([extint/0, extnum/0, frequency/0, length/0]).
+%% Internal types
 
 -include("proper_internal.hrl").
 
@@ -209,6 +212,7 @@
 %%------------------------------------------------------------------------------
 
 -type frequency() :: pos_integer().
+-type length()    :: non_neg_integer().
 
 -type type_kind() :: 'basic' | 'wrapper' | 'constructed' | 'container' | atom().
 -type instance_test() :: fun((proper_gen:imm_instance()) -> boolean())

--- a/src/proper_types.erl
+++ b/src/proper_types.erl
@@ -1,7 +1,7 @@
 %%% -*- coding: utf-8 -*-
 %%% -*- erlang-indent-level: 2 -*-
 %%% -------------------------------------------------------------------
-%%% Copyright 2010-2019 Manolis Papadakis <manopapad@gmail.com>,
+%%% Copyright 2010-2020 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>
 %%%
@@ -20,7 +20,7 @@
 %%% You should have received a copy of the GNU General Public License
 %%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
 
-%%% @copyright 2010-2019 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
+%%% @copyright 2010-2020 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
 %%% @version {@version}
 %%% @author Manolis Papadakis
 
@@ -162,7 +162,7 @@
 	 parameter/1, parameter/2]).
 -export([le/2]).
 
--export_type([type/0, raw_type/0, extint/0, extnum/0]).
+-export_type([type/0, raw_type/0, extint/0, extnum/0, frequency/0]).
 
 -include("proper_internal.hrl").
 
@@ -207,6 +207,8 @@
 %%------------------------------------------------------------------------------
 %% Types
 %%------------------------------------------------------------------------------
+
+-type frequency() :: pos_integer().
 
 -type type_kind() :: 'basic' | 'wrapper' | 'constructed' | 'container' | atom().
 -type instance_test() :: fun((proper_gen:imm_instance()) -> boolean())

--- a/src/proper_typeserver.erl
+++ b/src/proper_typeserver.erl
@@ -1,7 +1,7 @@
 %%% -*- coding: utf-8 -*-
 %%% -*- erlang-indent-level: 2 -*-
 %%% -------------------------------------------------------------------
-%%% Copyright 2010-2019 Manolis Papadakis <manopapad@gmail.com>,
+%%% Copyright 2010-2020 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>
 %%%
@@ -20,7 +20,7 @@
 %%% You should have received a copy of the GNU General Public License
 %%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
 
-%%% @copyright 2010-2019 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
+%%% @copyright 2010-2020 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
 %%% @version {@version}
 %%% @author Manolis Papadakis
 
@@ -246,8 +246,8 @@
 -type type_repr() :: {'abs_type',abs_type(),[var_name()],symb_info()}
 		   | {'cached',fin_type(),abs_type(),symb_info()}
 		   | {'abs_record',[{field_name(),abs_type()}]}.
--type gen_fun() :: fun((size()) -> fin_type()).
--type rec_fun() :: fun(([gen_fun()],size()) -> fin_type()).
+-type gen_fun() :: fun((proper_gen:size()) -> fin_type()).
+-type rec_fun() :: fun(([gen_fun()],proper_gen:size()) -> fin_type()).
 -type rec_arg() :: {boolean() | {'list',boolean(),rec_fun()},full_type_ref()}.
 -type rec_args() :: [rec_arg()].
 -type ret_type() :: {'simple',fin_type()} | {'rec',rec_fun(),rec_args()}.


### PR DESCRIPTION
Move many types that were defined in `proper_internal.hrl` to their proper defining module.

While at it, also introduce a `proper_target:strategy()` type.