### PR TITLE
Fix more_commands/2

### DIFF
--- a/src/proper_statem.erl
+++ b/src/proper_statem.erl
@@ -238,6 +238,8 @@
 -define(WORKERS, 2).
 -define(LIMIT, 12).
 
+-define(COMMANDS_SZ_FACTOR, '$commands_size_factor').
+-define(RESIZE_FACTOR, proper_types:parameter(?COMMANDS_SZ_FACTOR, 1)).
 
 %% -----------------------------------------------------------------------------
 %% Exported only for testing purposes
@@ -308,9 +310,10 @@ commands(Mod) ->
 	 ?SUCHTHAT(
 	    Cmds,
 	    ?LET(List,
-		 ?SIZED(Size,
-			proper_types:noshrink(
-			  commands(Size, Mod, InitialState, 1))),
+             ?SIZED(Size,
+                    proper_types:noshrink(
+                      commands(Size * ?RESIZE_FACTOR,
+                               Mod, InitialState, 1))),
 		 proper_types:shrink_list(List)),
 	    is_valid(Mod, InitialState, Cmds, []))).
 
@@ -327,11 +330,12 @@ commands(Mod, InitialState) ->
        Cmds,
        ?LET(CmdTail,
 	    ?LET(List,
-		 ?SIZED(Size,
-			proper_types:noshrink(
-			  commands(Size, Mod, InitialState, 1))),
-		 proper_types:shrink_list(List)),
-	    [{init,InitialState}|CmdTail]),
+             ?SIZED(Size,
+                    proper_types:noshrink(
+                      commands(Size * ?RESIZE_FACTOR,
+                               Mod, InitialState, 1))),
+             proper_types:shrink_list(List)),
+            [{init,InitialState}|CmdTail]),
        is_valid(Mod, InitialState, Cmds, [])).
 
 %% @private
@@ -358,7 +362,7 @@ commands(Size, Mod, State, Count) ->
 
 -spec more_commands(pos_integer(), proper_types:type()) -> proper_types:type().
 more_commands(N, CmdType) ->
-    ?SIZED(Size, proper_types:resize(Size * N, CmdType)).
+    proper_types:with_parameter(?COMMANDS_SZ_FACTOR, N, CmdType).
 
 
 %% -----------------------------------------------------------------------------


### PR DESCRIPTION
Original `more_commands/2` wasn't working as expected because the adjusting of
size with `resize/2` wasn't propagating to "deeper" types.

Fixes #192.

With these changes I get:

```
....................................................................................................
OK: Passed 100 test(s).

Length of Cmds
minimum: 0
average: 8.93
maximum: 36
....................................................................................................
OK: Passed 100 test(s).

Length of Cmds
minimum: 0
average: 96.33
maximum: 398
```