### PR TITLE
Fix targeted shrinking in USERNF

### DIFF
--- a/src/proper_types.erl
+++ b/src/proper_types.erl
@@ -290,7 +290,8 @@
     | {'parameters', [{atom(),value()}]}
     | {'env', term()}
     | {'subenv', term()}
-    | {'user_nf', proper_gen_next:nf()}.
+    | {'user_nf', proper_gen_next:nf()}
+    | {'is_user_nf', boolean()}.
 
 
 %%------------------------------------------------------------------------------

--- a/test/proper_tests.erl
+++ b/test/proper_tests.erl
@@ -1030,6 +1030,10 @@ false_props_test_() ->
 		     {stupid, ?FORALL(_, pos_integer(), throw(woot))}
 		 ]))),
      ?_fails(more_commands_test:prop_more_commands_fails(), [{numtests,42}]),
+     ?_failsWith([500], targeted_shrinking_test:prop_int()),
+     ?_failsWith([500], targeted_shrinking_test:prop_let_int()),
+     ?_failsWith([500], targeted_shrinking_test:prop_int_shrink_outer()),
+     ?_failsWith([500], targeted_shrinking_test:prop_int_shrink_inner()),
      {timeout, 20, ?_fails(ets_counter:prop_ets_counter())},
      ?_fails(post_false:prop_simple()),
      ?_fails(error_statem:prop_simple())].

--- a/test/targeted_shrinking_test.erl
+++ b/test/targeted_shrinking_test.erl
@@ -1,0 +1,129 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
+%%% Copyright 2020-     Manolis Papadakis <manopapad@gmail.com>,
+%%%                     Eirini Arvaniti <eirinibob@gmail.com>
+%%%                 and Kostis Sagonas <kostis@cs.ntua.gr>
+%%%
+%%% This file is part of PropEr.
+%%%
+%%% PropEr is free software: you can redistribute it and/or modify
+%%% it under the terms of the GNU General Public License as published by
+%%% the Free Software Foundation, either version 3 of the License, or
+%%% (at your option) any later version.
+%%%
+%%% PropEr is distributed in the hope that it will be useful,
+%%% but WITHOUT ANY WARRANTY; without even the implied warranty of
+%%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%%% GNU General Public License for more details.
+%%%
+%%% You should have received a copy of the GNU General Public License
+%%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
+
+%%% @copyright 2020 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
+%%% @version {@version}
+%%% @author Spiros Dontas
+
+%% -----------------------------------------------------------------------------
+%% Tests inspired by https://github.com/proper-testing/proper/issues/221
+%% -----------------------------------------------------------------------------
+
+-module(targeted_shrinking_test).
+-include_lib("proper/include/proper.hrl").
+-include_lib("eunit/include/eunit.hrl").
+
+%% -----------------------------------------------------------------------------
+%% Generators
+%% -----------------------------------------------------------------------------
+
+let_int() ->
+  ?LET(I, integer(), I).
+
+nf_let_int() ->
+  fun (Prev, _T) ->
+      ?LET(I, integer(Prev, inf), I)
+  end.
+
+nf_int_shrink() ->
+  fun (Prev, _T) ->
+      ?SHRINK(integer(Prev, inf), [integer()])
+  end.
+
+int_user_nf() ->
+  ?USERNF(integer(), nf_let_int()).
+
+let_int_user_nf() ->
+  ?USERNF(let_int(), nf_let_int()).
+
+int_user_nf_shrink_inner() ->
+  ?USERNF(let_int(), nf_int_shrink()).
+
+int_user_nf_shrink_outer() ->
+  ?USERNF(?SHRINK(let_int(), [integer()]),
+          fun(Prev, _T) -> integer(Prev, inf) end).
+
+normal_list() ->
+  list(integer()).
+
+let_list() ->
+  ?LET(L, list(integer()), L).
+
+nf_list() ->
+  fun (Prev, _T) ->
+      {Max, NewLen} = case Prev of
+                        [] -> {0, 1};
+                        _ -> {lists:max(Prev), length(Prev)}
+                      end,
+      ?SHRINK(?LET(L, vector(NewLen, integer(Max, inf)), Prev ++ L),
+              [list(integer())])
+  end.
+
+normal_list_user_nf() ->
+  ?USERNF(normal_list(), nf_list()).
+
+let_list_user_nf() ->
+  ?USERNF(let_list(), nf_list()).
+
+%% -----------------------------------------------------------------------------
+%% Properties
+%% -----------------------------------------------------------------------------
+
+property_int(I) ->
+  ?MAXIMIZE(I),
+  I < 500.
+
+prop_int() ->
+  ?FORALL_TARGETED(I, int_user_nf(), property_int(I)).
+
+prop_let_int() ->
+  ?FORALL_TARGETED(I, let_int_user_nf(), property_int(I)).
+
+prop_int_shrink_outer() ->
+  ?FORALL_TARGETED(I, int_user_nf_shrink_outer(), property_int(I)).
+
+prop_int_shrink_inner() ->
+  ?FORALL_TARGETED(I, int_user_nf_shrink_inner(), property_int(I)).
+
+property_list(L) ->
+  ?MAXIMIZE(lists:sum(L)),
+  lists:sum(L) < 1000.
+
+prop_normal_list() ->
+  ?FORALL_TARGETED(L, normal_list_user_nf(), property_list(L)).
+
+prop_let_list() ->
+  ?FORALL_TARGETED(L, let_list_user_nf(), property_list(L)).
+
+%% -----------------------------------------------------------------------------
+%% Tests
+%% -----------------------------------------------------------------------------
+
+normal_list_test() ->
+  false = proper:quickcheck(prop_normal_list()),
+  [L] = proper:counterexample(),
+  ?_assert(lists:sum(L) =:= 1000).
+
+let_list_test() ->
+  false = proper:quickcheck(prop_let_list()),
+  [L] = proper:counterexample(),
+  ?_assert(lists:sum(L) =:= 1000).


### PR DESCRIPTION
This commit fixes #221 and updates the way the targeted implementation
shrinks its instances. PropEr now tries to find the best shrinker
between the original generator and the neighborhood function.

Users can now also specify `?SHRINK` macros in the neighborhood
function, which will take precedence.