### PR TITLE
Modernize coverage generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,29 +17,10 @@ jobs:
   include:
     - language: erlang
       otp_release: 22.3
-      before_script:
-            - >
-                printf "\n{cover_enabled, true}.\n{cover_export_enabled, true}.
-                \n{cover_excl_mods, [
-                proper_array,
-                proper_dict,
-                proper_gb_sets,
-                proper_gb_trees,
-                proper_orddict,
-                proper_ordsets,
-                proper_prop_remover,
-                proper_queue,
-                proper_sets,
-                proper_transformer,
-                proper_unused_imports_remover,
-                vararg]}." >> rebar.config
+      env: COVER=true
       after_success:
-            - git clone https://github.com/covertool/covertool.git
-            - cd covertool && make compile && cd ..
-            - find _build/test/cover/ -name *.coverdata -exec ./covertool/covertool -cover {} -output {}.coverage.xml \;
-            - mv _build/test/cover/*.xml .
-            - rm -rf covertool/
-            - bash <(curl -s https://codecov.io/bash)
+        - for f in _build/test/covertool/*.xml; do cp "$f" $(basename "${f%.xml}.coverage.xml"); done
+        - bash <(curl -s https://codecov.io/bash)
 
 cache:
    directories:

--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ endif
 REBAR3_URL := https://s3.amazonaws.com/rebar3/rebar3
 REBAR3 ?= $(shell which rebar3 || which .$(SEP)rebar3 || \
             (wget $(REBAR3_URL) && chmod +x rebar3 && echo .$(SEP)rebar3))
+COVER ?= false
 
 default: compile
 
@@ -51,7 +52,11 @@ check_escripts:
 	./scripts/check_escripts.sh make_doc
 
 test:
+ifeq ($(COVER), true)
+	$(REBAR3) do eunit -c, cover, covertool generate
+else
 	$(REBAR3) eunit
+endif
 
 doc: compile
 	./scripts/make_doc

--- a/rebar.config
+++ b/rebar.config
@@ -40,10 +40,28 @@
 	    warn_missing_spec, warn_untyped_record,
 	    {platform_define, "^2", 'AT_LEAST_20'}]}.
 
-{profiles, [{test, [{erl_opts, [nowarn_untyped_record,
-				nowarn_missing_spec]}]}]}.
+{profiles,
+ [{test,
+   [{erl_opts, [nowarn_untyped_record,
+                nowarn_missing_spec]},
+    {cover_excl_mods, [proper_array,
+                       proper_dict,
+                       proper_gb_sets,
+                       proper_gb_trees,
+                       proper_orddict,
+                       proper_ordsets,
+                       proper_prop_remover,
+                       proper_queue,
+                       proper_sets,
+                       proper_transformer,
+                       proper_unused_imports_remover,
+                       vararg]}]}]}.
 
 {post_hooks, [{clean, "./scripts/clean_doc.sh"}]}.
 
 {dialyzer, [{warnings, [unmatched_returns, unknown]},
             {plt_extra_apps, [erts, kernel, stdlib, compiler, crypto, syntax_tools, eunit]}]}.
+
+{plugins, [covertool]}.
+{cover_export_enabled, true}.
+{covertool, [{coverdata_files, ["eunit.coverdata"]}]}.


### PR DESCRIPTION
This commit updates the rebar3 configuration, so that the
covertool plugin is used to produce the coverage report.