### PR TITLE
Stateful Targeted Property-Based Testing

### DIFF
--- a/examples/car.inc
+++ b/examples/car.inc
@@ -1,0 +1,132 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
+%%% Copyright 2020-     Manolis Papadakis <manopapad@gmail.com>,
+%%%                     Eirini Arvaniti <eirinibob@gmail.com>
+%%%                 and Kostis Sagonas <kostis@cs.ntua.gr>
+%%%
+%%% This file is part of PropEr.
+%%%
+%%% PropEr is free software: you can redistribute it and/or modify
+%%% it under the terms of the GNU General Public License as published by
+%%% the Free Software Foundation, either version 3 of the License, or
+%%% (at your option) any later version.
+%%%
+%%% PropEr is distributed in the hope that it will be useful,
+%%% but WITHOUT ANY WARRANTY; without even the implied warranty of
+%%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%%% GNU General Public License for more details.
+%%%
+%%% You should have received a copy of the GNU General Public License
+%%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
+
+%%% @copyright 2020 Spiros Dontas and Kostis Sagonas
+%%% @version {@version}
+%%% @author Spiros Dontas
+
+
+%% -----------------------------------------------------------------------------
+%% Macros
+%% -----------------------------------------------------------------------------
+
+
+-define(HOUR, 3600).
+-define(ACCELERATION, 5).
+-define(DECELERATION, 20).
+-define(MAX_FUEL, 70).
+-define(MAX_SPEED, 200).
+-define(AVG(X), lists:sum(X) / length(X)).
+-define(NAME, car).
+-define(CALL(C, A), {call, ?MODULE, C, A}).
+
+
+%% -----------------------------------------------------------------------------
+%% Calculation Functions
+%% -----------------------------------------------------------------------------
+
+
+travel_calculations(Distance, Speed, Fuel) when Speed > 0 ->
+  Consumption = fuel_consumption(Speed),
+  Burn = Consumption * Distance / 100,
+  case Burn > Fuel of
+    true -> {Fuel * 100 / Consumption, Fuel};
+    false -> {Distance, Burn}
+  end;
+travel_calculations(_D, _S, _F) ->
+  {0, 0.0}.
+
+acceleration_calculations(Speed, Accel, Fuel) when Accel > 0 ->
+  Acceleration = case Speed + Accel > ?MAX_SPEED of
+                   true -> ?MAX_SPEED - Speed;
+                   false -> Accel
+                 end,
+  Consumption = fuel_consumption(Speed, Acceleration),
+  Distance = calculate_distance(Speed, Acceleration),
+  Burn = Consumption * Distance / 100,
+  case Burn > Fuel of
+    true ->
+      acceleration_calculations(Speed, Acceleration - ?ACCELERATION, Fuel);
+    false ->
+      {Distance, Acceleration, Burn}
+  end;
+acceleration_calculations(Speed, Accel, Fuel) ->
+  Acceleration = case Speed + Accel < 0 of
+                   true -> -Speed;
+                   false -> Accel
+                 end,
+  Consumption = fuel_consumption(Speed, Acceleration),
+  Distance = calculate_distance(Speed, Acceleration),
+  Burn = Consumption * Distance / 100,
+  case Burn > Fuel of
+    true -> {Distance, Acceleration, Fuel};
+    false -> {Distance, Acceleration, Burn}
+  end.
+
+
+calculate_consumption(0, _Burnt) -> 0;
+calculate_consumption(Distance, Burnt) -> 100 * Burnt / Distance.
+
+
+%% -----------------------------------------------------------------------------
+%% Helpers
+%% -----------------------------------------------------------------------------
+
+
+%% Calculate distance driven when accelerating - decelerating.
+calculate_distance(Speed, Acceleration) when Acceleration > 0 ->
+  T = Acceleration / ?ACCELERATION,
+  Speed / ?HOUR * T + 1 / 2 * ?ACCELERATION / ?HOUR * T * T;
+calculate_distance(Speed, Acceleration)->
+  T = -Acceleration / ?DECELERATION,
+  Speed / ?HOUR * T - 1 / 2 * ?DECELERATION / ?HOUR * T * T.
+
+%% Low speeds give rewards to consumption.
+%% High speed give penalty to consumption.
+fuel_speed_penalty(Speed) when Speed =< 50 -> 0.7;
+fuel_speed_penalty(Speed) when Speed =< 100 -> 0.9;
+fuel_speed_penalty(Speed) when Speed =< 150 -> 1.1;
+fuel_speed_penalty(_) -> 1.5.
+
+%% Acceleration penalty.
+%% Deceleration reward.
+fuel_acceleration_penalty(Acceleration) when Acceleration > 0 -> 2.0;
+fuel_acceleration_penalty(_) -> 0.1.
+
+%% Fuel Consumption (stable speed).
+fuel_consumption(Speed) ->
+  Speed * fuel_speed_penalty(Speed) / 10.
+
+%% Fuel Consumption (acc - dec).
+fuel_consumption(Speed, Acceleration) ->
+  Penalty = fuel_acceleration_penalty(Acceleration),
+  Intermediate = intermediate_speeds(Speed, Acceleration),
+  Consumptions = [fuel_consumption(S) * Penalty || S <- Intermediate],
+  ?AVG(Consumptions).
+
+%% Intermediate speeds from accelerating - decelerating.
+intermediate_speeds(Speed, Acceleration) when Acceleration > 0 ->
+  T = Acceleration / ?ACCELERATION,
+  [Speed + X / 10 * ?ACCELERATION || X <- lists:seq(0, round(T * 10))];
+intermediate_speeds(Speed, Acceleration) ->
+  T = -Acceleration / ?DECELERATION,
+  [Speed - X / 10 * ?DECELERATION || X <- lists:seq(0, round(T * 10))].

--- a/examples/car_fsm.erl
+++ b/examples/car_fsm.erl
@@ -52,8 +52,8 @@
 %% -----------------------------------------------------------------------------
 
 
--define(DISTANCE, 1000).
--define(CONSUMPTION, 10).
+-define(DISTANCE, 800).
+-define(CONSUMPTION, 12).
 -define(SLOW_THRESHOLD, 50).
 -define(NORMAL_THRESHOLD, 100).
 -define(FAST_THRESHOLD, 150).
@@ -342,8 +342,6 @@ postcondition(_, _, S, _, {D, B}) ->
   Wanted = Distance + D >= ?DISTANCE andalso Consumption =< ?CONSUMPTION,
   D >= 0.0 andalso B >= 0.0 andalso not Wanted.
 
-weight(_, _, ?CALL(brake, _)) -> 2;
-weight(_, _, ?CALL(travel, _)) -> 4;
 weight(_, _, _) -> 1.
 
 
@@ -396,7 +394,7 @@ prop_distance() ->
 %% provides failing command sequencies more consistently.
 prop_distance_targeted() ->
   ?FORALL_TARGETED(
-     Cmds, more_commands(3, proper_fsm:targeted_commands(?MODULE)),
+     Cmds, proper_fsm:targeted_commands(?MODULE),
      ?TRAPEXIT(
         begin
           start_link(),
@@ -414,7 +412,7 @@ prop_distance_targeted() ->
 prop_distance_targeted_init() ->
   State = {initial_state(), initial_state_data()},
   ?FORALL_TARGETED(
-     Cmds, more_commands(3, proper_fsm:targeted_commands(?MODULE, State)),
+     Cmds, proper_fsm:targeted_commands(?MODULE, State),
      ?TRAPEXIT(
         begin
           start_link(),

--- a/examples/car_fsm.erl
+++ b/examples/car_fsm.erl
@@ -1,7 +1,7 @@
 %%% -*- coding: utf-8 -*-
 %%% -*- erlang-indent-level: 2 -*-
 %%% -------------------------------------------------------------------
-%%% Copyright 2010-2020 Manolis Papadakis <manopapad@gmail.com>,
+%%% Copyright 2020-     Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>
 %%%
@@ -20,7 +20,7 @@
 %%% You should have received a copy of the GNU General Public License
 %%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
 
-%%% @copyright 2010-2020 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
+%%% @copyright 2020 Spiros Dontas and Kostis Sagonas
 %%% @version {@version}
 %%% @author Spiros Dontas
 
@@ -29,8 +29,6 @@
 -behaviour(proper_fsm).
 
 -include_lib("proper/include/proper.hrl").
-
--compile([export_all, nowarn_export_all]).
 
 
 %% -----------------------------------------------------------------------------
@@ -47,9 +45,6 @@
 -export([initial_state/0, initial_state_data/0, next_state_data/5,
          precondition/4, postcondition/5, weight/3]).
 -export([stopped/1, slow/1, normal/1, fast/1, too_fast/1]).
-%% Properties
--export([prop_distance/0, prop_distance_targeted/0,
-         prop_distance_targeted_init/0]).
 
 
 %% -----------------------------------------------------------------------------
@@ -164,12 +159,6 @@ too_fast({call, From}, {travel, Value}, S) ->
 too_fast({call, From}, {refuel, Value}, S) ->
   refuel_helper(From, Value, S).
 
-handle_call(From, stop, Data) ->
-  {stop_and_reply, normal, {reply, From, ok}, Data}.
-
-handle_info(Info, StateName, Data) ->
-  {stop, {shutdown, {unexpected, Info, StateName}}, StateName, Data}.
-
 terminate(_Reason, _StateName, _State) ->
   ok.
 
@@ -260,29 +249,29 @@ slow(S) ->
   #state{fuel = Fuel, speed = Speed} = S,
   accelerate_commands(Speed) ++
     brake_commands(Speed) ++
-    [{history, ?CALL(travel, [traveler()])}] ++
-    [{stopped, ?CALL(refuel, [refueler(Fuel)])}].
+    [{history, ?CALL(travel, [traveler()])},
+     {stopped, ?CALL(refuel, [refueler(Fuel)])}].
 
 normal(S) ->
   #state{fuel = Fuel, speed = Speed} = S,
   accelerate_commands(Speed) ++
     brake_commands(Speed) ++
-    [{history, ?CALL(travel, [traveler()])}] ++
-    [{stopped, ?CALL(refuel, [refueler(Fuel)])}].
+    [{history, ?CALL(travel, [traveler()])},
+     {stopped, ?CALL(refuel, [refueler(Fuel)])}].
 
 fast(S) ->
   #state{fuel = Fuel, speed = Speed} = S,
   accelerate_commands(Speed) ++
     brake_commands(Speed) ++
-    [{history, ?CALL(travel, [traveler()])}] ++
-    [{stopped, ?CALL(refuel, [refueler(Fuel)])}].
+    [{history, ?CALL(travel, [traveler()])},
+     {stopped, ?CALL(refuel, [refueler(Fuel)])}].
 
 too_fast(S) ->
   #state{fuel = Fuel, speed = Speed} = S,
   accelerate_commands(Speed) ++
     brake_commands(Speed) ++
-    [{history, ?CALL(travel, [traveler()])}] ++
-    [{stopped, ?CALL(refuel, [refueler(Fuel)])}].
+    [{history, ?CALL(travel, [traveler()])},
+     {stopped, ?CALL(refuel, [refueler(Fuel)])}].
 
 precondition(stopped, stopped, _S, {call, _, refuel, _}) ->
   true;
@@ -354,6 +343,7 @@ postcondition(_, _, _, _, {Distance, Burnt}) ->
 %% Uncomment the following line to make the search faster.
 % weight(_, _, {call, _, travel, _}) -> 10;
 weight(_, _, _) -> 1.
+
 
 %% -----------------------------------------------------------------------------
 %% proper_fsm helpers

--- a/examples/car_fsm.erl
+++ b/examples/car_fsm.erl
@@ -1,0 +1,559 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
+%%% Copyright 2010-2020 Manolis Papadakis <manopapad@gmail.com>,
+%%%                     Eirini Arvaniti <eirinibob@gmail.com>
+%%%                 and Kostis Sagonas <kostis@cs.ntua.gr>
+%%%
+%%% This file is part of PropEr.
+%%%
+%%% PropEr is free software: you can redistribute it and/or modify
+%%% it under the terms of the GNU General Public License as published by
+%%% the Free Software Foundation, either version 3 of the License, or
+%%% (at your option) any later version.
+%%%
+%%% PropEr is distributed in the hope that it will be useful,
+%%% but WITHOUT ANY WARRANTY; without even the implied warranty of
+%%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%%% GNU General Public License for more details.
+%%%
+%%% You should have received a copy of the GNU General Public License
+%%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
+
+%%% @copyright 2010-2020 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
+%%% @version {@version}
+%%% @author Spiros Dontas
+
+-module(car_fsm).
+-behaviour(gen_statem).
+-behaviour(proper_fsm).
+
+-include_lib("proper/include/proper.hrl").
+
+-compile([export_all, nowarn_export_all]).
+
+
+%% -----------------------------------------------------------------------------
+%% Exports
+%% -----------------------------------------------------------------------------
+
+
+%% API
+-export([start_link/0, stop/0, accelerate/1, brake/1, travel/1, refuel/1]).
+%% gen_statem callbacks
+-export([init/1, callback_mode/0, stopped/3, slow/3, normal/3, fast/3,
+         too_fast/3, terminate/3, code_change/4]).
+%% proper_fsm callbacks
+-export([initial_state/0, initial_state_data/0, next_state_data/5,
+         precondition/4, postcondition/5, weight/3]).
+-export([stopped/1, slow/1, normal/1, fast/1, too_fast/1]).
+%% Properties
+-export([prop_distance/0, prop_distance_targeted/0,
+         prop_distance_targeted_init/0]).
+
+
+%% -----------------------------------------------------------------------------
+%% Definitions
+%% -----------------------------------------------------------------------------
+
+
+-define(DISTANCE, 1000).
+-define(CONSUMPTION, 10).
+-define(HOUR, 3600).
+-define(ACCELERATION, 5).
+-define(DECELERATION, 20).
+-define(MAX_FUEL, 70).
+-define(MAX_SPEED, 200).
+-define(AVG(X), lists:sum(X) / length(X)).
+-define(SLOW_THRESHOLD, 50).
+-define(NORMAL_THRESHOLD, 100).
+-define(FAST_THRESHOLD, 150).
+-define(CALL(C, A), {call, ?MODULE, C, A}).
+-define(NAME, car).
+
+
+%% -----------------------------------------------------------------------------
+%% Records
+%% -----------------------------------------------------------------------------
+
+
+-record(gen_state,
+        {fuel  :: float(),
+         speed :: non_neg_integer()}).
+
+-record(state,
+        {fuel     :: float(),
+         speed    :: non_neg_integer(),
+         distance :: float(),
+         burnt    :: float()}).
+
+
+%% -----------------------------------------------------------------------------
+%% API
+%% -----------------------------------------------------------------------------
+
+
+start_link() ->
+  gen_statem:start_link({local, ?NAME}, ?MODULE, [], []).
+
+stop() ->
+  gen_statem:stop(?NAME).
+
+accelerate(Value) ->
+  gen_statem:call(?NAME, {accelerate, Value}).
+
+brake(Value) ->
+  gen_statem:call(?NAME, {brake, Value}).
+
+travel(Distance) ->
+  gen_statem:call(?NAME, {travel, Distance}).
+
+refuel(Amount) ->
+  gen_statem:call(?NAME, {refuel, Amount}).
+
+
+%% -----------------------------------------------------------------------------
+%% gen_statem callbacks
+%% -----------------------------------------------------------------------------
+
+
+init([]) ->
+  {ok, stopped, #gen_state{fuel = ?MAX_FUEL, speed = 0}}.
+
+callback_mode() ->
+  state_functions.
+
+stopped({call, From}, {accelerate, Value}, S) ->
+  accelerate_helper(From, Value, S);
+stopped({call, From}, {refuel, Value}, S) ->
+  refuel_helper(From, Value, S).
+
+slow({call, From}, {accelerate, Value}, S) ->
+  accelerate_helper(From, Value, S);
+slow({call, From}, {brake, Value}, S) ->
+  accelerate_helper(From, -Value, S);
+slow({call, From}, {travel, Value}, S) ->
+  travel_helper(From, Value, S);
+slow({call, From}, {refuel, Value}, S) ->
+  refuel_helper(From, Value, S).
+
+normal({call, From}, {accelerate, Value}, S) ->
+  accelerate_helper(From, Value, S);
+normal({call, From}, {brake, Value}, S) ->
+  accelerate_helper(From, -Value, S);
+normal({call, From}, {travel, Value}, S) ->
+  travel_helper(From, Value, S);
+normal({call, From}, {refuel, Value}, S) ->
+  refuel_helper(From, Value, S).
+
+fast({call, From}, {accelerate, Value}, S) ->
+  accelerate_helper(From, Value, S);
+fast({call, From}, {brake, Value}, S) ->
+  accelerate_helper(From, -Value, S);
+fast({call, From}, {travel, Value}, S) ->
+  travel_helper(From, Value, S);
+fast({call, From}, {refuel, Value}, S) ->
+  refuel_helper(From, Value, S).
+
+too_fast({call, From}, {accelerate, Value}, S) ->
+  accelerate_helper(From, Value, S);
+too_fast({call, From}, {brake, Value}, S) ->
+  accelerate_helper(From, -Value, S);
+too_fast({call, From}, {travel, Value}, S) ->
+  travel_helper(From, Value, S);
+too_fast({call, From}, {refuel, Value}, S) ->
+  refuel_helper(From, Value, S).
+
+handle_call(From, stop, Data) ->
+  {stop_and_reply, normal, {reply, From, ok}, Data}.
+
+handle_info(Info, StateName, Data) ->
+  {stop, {shutdown, {unexpected, Info, StateName}}, StateName, Data}.
+
+terminate(_Reason, _StateName, _State) ->
+  ok.
+
+code_change(_OldVsn, StateName, State, _Extra) ->
+  {ok, StateName, State}.
+
+
+%% -----------------------------------------------------------------------------
+%% gen_statem helpers
+%% -----------------------------------------------------------------------------
+
+
+accelerate_helper(From, Value, S) ->
+  #gen_state{fuel = Fuel, speed = Speed} = S,
+  {Distance, Acceleration, Burnt} =
+    acceleration_calculations({Speed, Value}, Fuel),
+  StateName = state_name(Speed + Acceleration),
+  gen_statem:reply(From, {Distance, Burnt}),
+  {next_state, StateName, S#gen_state{fuel = Fuel - Burnt,
+                                      speed = Speed + Acceleration}}.
+
+travel_helper(From, Value, S) ->
+  #gen_state{fuel = Fuel, speed = Speed} = S,
+  {RealDistance, Burnt} = travel_calculations(Value, Speed, Fuel),
+  StateName = state_name(Speed),
+  gen_statem:reply(From, {RealDistance, Burnt}),
+  {next_state, StateName, S#gen_state{fuel = Fuel - Burnt}}.
+
+refuel_helper(From, Value, S) ->
+  #gen_state{fuel = Fuel, speed = Speed} = S,
+  {Distance, _Deceleration, Burnt} =
+    acceleration_calculations({Speed, -Speed}, Fuel),
+  gen_statem:reply(From, {Distance, Burnt}),
+  {next_state, state_name(0),
+   S#gen_state{fuel = min(?MAX_FUEL, Fuel - Burnt + Value),speed = 0}}.
+
+
+%% -----------------------------------------------------------------------------
+%% Generators
+%% -----------------------------------------------------------------------------
+
+
+accelerator(Speed, slow) ->
+  integer(1, ?SLOW_THRESHOLD - Speed);
+accelerator(Speed, normal) ->
+  integer(max(1, ?SLOW_THRESHOLD - Speed + 1), ?NORMAL_THRESHOLD - Speed);
+accelerator(Speed, fast) ->
+  integer(max(1, ?NORMAL_THRESHOLD - Speed + 1), ?FAST_THRESHOLD - Speed);
+accelerator(Speed, too_fast) ->
+  integer(max(1, ?FAST_THRESHOLD - Speed + 1), ?MAX_SPEED - Speed).
+
+braker(Speed, stopped) ->
+  exactly(Speed);
+braker(Speed, slow) ->
+  integer(max(1, Speed - ?SLOW_THRESHOLD + 1), Speed - 1);
+braker(Speed, normal) ->
+  integer(max(1, Speed - ?NORMAL_THRESHOLD + 1), Speed - ?SLOW_THRESHOLD - 1);
+braker(Speed, fast) ->
+  integer(max(1, Speed - ?FAST_THRESHOLD + 1), Speed - ?NORMAL_THRESHOLD - 1);
+braker(Speed, too_fast) ->
+  integer(1, Speed - ?FAST_THRESHOLD - 1).
+
+traveler() -> integer(1, 100).
+
+refueler(Fuel) -> integer(0, round(?MAX_FUEL - Fuel)).
+
+
+%% -----------------------------------------------------------------------------
+%% proper_fsm callbacks
+%% -----------------------------------------------------------------------------
+
+
+initial_state() -> stopped.
+
+initial_state_data() ->
+  #state{fuel     = ?MAX_FUEL,
+         speed    = 0,
+         burnt    = 0,
+         distance = 0}.
+
+stopped(S) ->
+  #state{fuel = Fuel, speed = Speed} = S,
+  accelerate_commands(Speed) ++
+    [{history, {call, ?MODULE, refuel, [refueler(Fuel)]}}
+     || Fuel < ?MAX_FUEL - 1].
+
+slow(S) ->
+  #state{fuel = Fuel, speed = Speed} = S,
+  accelerate_commands(Speed) ++
+    brake_commands(Speed) ++
+    [{history, ?CALL(travel, [traveler()])}] ++
+    [{stopped, ?CALL(refuel, [refueler(Fuel)])}].
+
+normal(S) ->
+  #state{fuel = Fuel, speed = Speed} = S,
+  accelerate_commands(Speed) ++
+    brake_commands(Speed) ++
+    [{history, ?CALL(travel, [traveler()])}] ++
+    [{stopped, ?CALL(refuel, [refueler(Fuel)])}].
+
+fast(S) ->
+  #state{fuel = Fuel, speed = Speed} = S,
+  accelerate_commands(Speed) ++
+    brake_commands(Speed) ++
+    [{history, ?CALL(travel, [traveler()])}] ++
+    [{stopped, ?CALL(refuel, [refueler(Fuel)])}].
+
+too_fast(S) ->
+  #state{fuel = Fuel, speed = Speed} = S,
+  accelerate_commands(Speed) ++
+    brake_commands(Speed) ++
+    [{history, ?CALL(travel, [traveler()])}] ++
+    [{stopped, ?CALL(refuel, [refueler(Fuel)])}].
+
+precondition(stopped, stopped, _S, {call, _, refuel, _}) ->
+  true;
+precondition(_, NextState, S, {call, _, accelerate, [Value]}) ->
+  #state{fuel = Fuel, speed = Speed} = S,
+  Speed < ?MAX_SPEED andalso
+    Fuel > ?MAX_FUEL * 0.1 andalso
+    state_name(Speed + Value) =:= NextState;
+precondition(_, NextState, S, {call, _, brake, [Value]}) ->
+  #state{speed = Speed} = S,
+  state_name(Speed - Value) =:= NextState;
+precondition(PrevState, NextState, S, {call, _, travel, _}) ->
+  #state{speed = Speed} = S,
+  Speed > 20 andalso PrevState =:= NextState;
+precondition(_, stopped, S, {call, _, refuel, _}) ->
+  #state{fuel = Fuel} = S,
+  Fuel < ?MAX_FUEL * 0.8;
+precondition(_, _, _, _) ->
+  false.
+
+next_state_data(_, _, S, _, {call, _, accelerate, [Value]}) ->
+  #state{fuel = Fuel,
+         speed = Speed,
+         distance = Distance,
+         burnt = B} = S,
+  {Travelled, Acceleration, Burnt} =
+    acceleration_calculations({Speed, Value}, Fuel),
+  S#state{fuel = Fuel - Burnt,
+          speed = Speed + Acceleration,
+          distance = Distance + Travelled,
+          burnt = B + Burnt};
+next_state_data(_, _, S, _, {call, _, brake, [Value]}) ->
+  #state{fuel = Fuel,
+         speed = Speed,
+         distance = Distance,
+         burnt = B} = S,
+  {Travelled, Acceleration, Burnt} =
+    acceleration_calculations({Speed, -Value}, Fuel),
+  S#state{fuel = Fuel - Burnt,
+          speed = Speed + Acceleration,
+          distance = Distance + Travelled,
+          burnt = B + Burnt};
+next_state_data(_, _, S, _, {call, _, travel, [Value]}) ->
+  #state{fuel = Fuel,
+         speed = Speed,
+         distance = Distance,
+         burnt = B} = S,
+  {Travelled, Burnt} = travel_calculations(Value, Speed, Fuel),
+  S#state{fuel = Fuel - Burnt,
+          distance = Distance + Travelled,
+          burnt = B + Burnt};
+next_state_data(_, _, S, _, {call, _, refuel, [Value]}) ->
+  #state{fuel = Fuel,
+         speed = Speed,
+         distance = Distance,
+         burnt = B} = S,
+  {Travelled, Acceleration, Burnt} =
+    acceleration_calculations({Speed, -Speed}, Fuel),
+  S#state{fuel = Fuel - Burnt + Value,
+          speed = Speed + Acceleration,
+          distance = Distance + Travelled,
+          burnt = B + Burnt}.
+
+postcondition(stopped, stopped, _, {call, _, refuel, _}, {0.0, 0.0}) ->
+  true;
+postcondition(_, _, _, _, {Distance, Burnt}) ->
+  Distance >= 0.0 andalso Burnt >= 0.0.
+
+%% Uncomment the following line to make the search faster.
+% weight(_, _, {call, _, travel, _}) -> 10;
+weight(_, _, _) -> 1.
+
+%% -----------------------------------------------------------------------------
+%% proper_fsm helpers
+%% -----------------------------------------------------------------------------
+
+
+accelerate_commands(Speed) ->
+  [{slow, ?CALL(accelerate, [accelerator(Speed, slow)])}
+   || Speed < ?SLOW_THRESHOLD] ++
+    [{normal, ?CALL(accelerate, [accelerator(Speed, normal)])}
+     || Speed < ?NORMAL_THRESHOLD] ++
+    [{fast, ?CALL(accelerate, [accelerator(Speed, fast)])}
+     || Speed < ?FAST_THRESHOLD] ++
+    [{too_fast, ?CALL(accelerate, [accelerator(Speed, too_fast)])}
+     || Speed < ?MAX_SPEED].
+
+brake_commands(Speed) ->
+  [{stopped, ?CALL(brake, [braker(Speed, stopped)])}] ++
+    [{slow, ?CALL(brake, [braker(Speed, slow)])} || Speed > 1] ++
+    [{normal, ?CALL(brake, [braker(Speed, normal)])}
+     || Speed > ?SLOW_THRESHOLD + 1] ++
+    [{fast, ?CALL(brake, [braker(Speed, fast)])}
+     || Speed > ?NORMAL_THRESHOLD + 1] ++
+    [{too_fast, ?CALL(brake, [braker(Speed, too_fast)])}
+     || Speed > ?FAST_THRESHOLD + 1].
+
+
+%% -----------------------------------------------------------------------------
+%% Properties
+%% -----------------------------------------------------------------------------
+
+
+%% This should "never" fail:<br/>
+%% `proper:quickcheck(car_fsm:prop_normal_distance(), 1000).'
+prop_distance() ->
+  ?FORALL(Cmds, proper_fsm:commands(?MODULE),
+          ?TRAPEXIT(
+             begin
+               start_link(),
+               {_H, {_, S}, R} = proper_fsm:run_commands(?MODULE, Cmds),
+               stop(),
+               #state{distance = Distance, burnt = Burnt} = S,
+               Consumption = case Distance > 0 of
+                               true -> 100 * Burnt / Distance;
+                               false -> 0
+                             end,
+               ?WHENFAIL(
+                  io:format("Distance: ~p~nConsumption: ~p~n",
+                            [Distance, Consumption]),
+                  aggregate(command_names(Cmds),
+                            R =:= ok andalso (Distance < ?DISTANCE orelse
+                                              Consumption > ?CONSUMPTION)))
+             end)).
+
+%% This should fail most of the times with:<br/>
+%% `proper:quickcheck(car_fsm:prop_targeted_distance(), 1000).'
+prop_distance_targeted() ->
+  ?FORALL_TARGETED(
+     Cmds, more_commands(2, proper_fsm:targeted_commands(?MODULE)),
+     ?TRAPEXIT(
+        begin
+          start_link(),
+          {_H, {_, S}, R} = proper_fsm:run_commands(?MODULE, Cmds),
+          stop(),
+          #state{distance = Distance, burnt = Burnt} = S,
+          Consumption = case Distance > 0 of
+                          true -> 100 * Burnt / Distance;
+                          false -> 0
+                        end,
+          UV = case Consumption > ?CONSUMPTION of
+                 true -> Distance * 0.1;
+                 false -> Distance
+               end,
+          ?MAXIMIZE(UV),
+          ?WHENFAIL(
+             io:format("Distance: ~p~nConsumption: ~p~n",
+                       [Distance, Consumption]),
+             aggregate(command_names(Cmds),
+                       R =:= ok andalso (Distance < ?DISTANCE orelse
+                                         Consumption > ?CONSUMPTION)))
+        end)).
+
+%% This should fail most of the times with:<br/>
+%% `proper:quickcheck(car_fsm:prop_targeted_distance_init(), 1000).'
+prop_distance_targeted_init() ->
+  State = {initial_state(), initial_state_data()},
+  ?FORALL_TARGETED(
+     Cmds, more_commands(2, proper_fsm:targeted_commands(?MODULE, State)),
+     ?TRAPEXIT(
+        begin
+          start_link(),
+          {_H, {_, S}, R} = proper_fsm:run_commands(?MODULE, Cmds),
+          stop(),
+          #state{distance = Distance, burnt = Burnt} = S,
+          Consumption = case Distance > 0 of
+                          true -> 100 * Burnt / Distance;
+                          false -> 0
+                        end,
+          UV = case Consumption > ?CONSUMPTION of
+                 true -> Distance * 0.1;
+                 false -> Distance
+               end,
+          ?MAXIMIZE(UV),
+          ?WHENFAIL(
+             io:format("Distance: ~p~nConsumption: ~p~n",
+                       [Distance, Consumption]),
+             aggregate(command_names(Cmds),
+                       R =:= ok andalso (Distance < ?DISTANCE orelse
+                                         Consumption > ?CONSUMPTION)))
+        end)).
+
+%% -----------------------------------------------------------------------------
+%% Calculation Functions
+%% -----------------------------------------------------------------------------
+
+
+travel_calculations(Distance, Speed, Fuel) when Speed > 0 ->
+  Consumption = fuel_consumption(Speed),
+  Burn = Consumption * Distance / 100,
+  case Burn > Fuel of
+    true -> {Fuel * 100 / Consumption, Fuel};
+    false -> {Distance, Burn}
+  end;
+travel_calculations(_D, _S, _F) ->
+  {0, 0.0}.
+
+acceleration_calculations({Speed, Accel}, Fuel) when Accel > 0 ->
+  Acceleration = case Speed + Accel > ?MAX_SPEED of
+                   true -> ?MAX_SPEED - Speed;
+                   false -> Accel
+                 end,
+  Consumption = fuel_consumption(Speed, Acceleration),
+  Distance = calculate_distance(Speed, Acceleration),
+  Burn = Consumption * Distance / 100,
+  case Burn > Fuel of
+    true -> acceleration_calculations({Speed, Acceleration - ?ACCELERATION},
+                                      Fuel);
+    false -> {Distance, Acceleration, Burn}
+  end;
+acceleration_calculations({Speed, Accel}, Fuel) ->
+  Acceleration = case Speed + Accel < 0 of
+                   true -> -Speed;
+                   false -> Accel
+                 end,
+  Consumption = fuel_consumption(Speed, Acceleration),
+  Distance = calculate_distance(Speed, Acceleration),
+  Burn = Consumption * Distance / 100,
+  case Burn > Fuel of
+    true -> {Distance, Acceleration, Fuel};
+    false -> {Distance, Acceleration, Burn}
+  end.
+
+
+%% -----------------------------------------------------------------------------
+%% Helpers
+%% -----------------------------------------------------------------------------
+
+
+%% Calculate distance driven when accelerating - decelerating.
+calculate_distance(Speed, Acceleration) when Acceleration > 0 ->
+  T = Acceleration / ?ACCELERATION,
+  Speed / ?HOUR * T + 1 / 2 * ?ACCELERATION / ?HOUR * T * T;
+calculate_distance(Speed, Acceleration)->
+  T = -Acceleration / ?DECELERATION,
+  Speed / ?HOUR * T - 1 / 2 * ?DECELERATION / ?HOUR * T * T.
+
+%% Low speeds give rewards to consumption.
+%% High speed give penalty to consumption.
+fuel_speed_penalty(Speed) when Speed =< ?SLOW_THRESHOLD -> 0.7;
+fuel_speed_penalty(Speed) when Speed =< ?NORMAL_THRESHOLD -> 0.9;
+fuel_speed_penalty(Speed) when Speed =< ?FAST_THRESHOLD -> 1.1;
+fuel_speed_penalty(_) -> 1.5.
+
+%% Acceleration penalty.
+%% Deceleration reward.
+fuel_acceleration_penalty(Acceleration) when Acceleration > 0 -> 2.0;
+fuel_acceleration_penalty(_) -> 0.1.
+
+%% Fuel Consumption (stable speed).
+fuel_consumption(Speed) ->
+  Speed * fuel_speed_penalty(Speed) / 10.
+
+%% Fuel Consumption (acc - dec).
+fuel_consumption(Speed, Acceleration) ->
+  Consumptions = [fuel_consumption(S) *
+                    fuel_acceleration_penalty(Acceleration)
+                  || S <- intermediate_speeds(Speed, Acceleration)],
+  ?AVG(Consumptions).
+
+%% Intermediate speeds from accelerating - decelerating.
+intermediate_speeds(Speed, Acceleration) when Acceleration > 0 ->
+  T = Acceleration / ?ACCELERATION,
+  [Speed + X / 10 * ?ACCELERATION || X <- lists:seq(0, round(T * 10))];
+intermediate_speeds(Speed, Acceleration) ->
+  T = -Acceleration / ?DECELERATION,
+  [Speed - X / 10 * ?DECELERATION || X <- lists:seq(0, round(T * 10))].
+
+%% Get state names based on speed.
+state_name(0) -> stopped;
+state_name(S) when S =< ?SLOW_THRESHOLD -> slow;
+state_name(S) when S =< ?NORMAL_THRESHOLD -> normal;
+state_name(S) when S =< ?FAST_THRESHOLD -> fast;
+state_name(_S) -> too_fast.

--- a/examples/car_fsm.erl
+++ b/examples/car_fsm.erl
@@ -340,8 +340,8 @@ postcondition(stopped, stopped, _, {call, _, refuel, _}, {0.0, 0.0}) ->
 postcondition(_, _, _, _, {Distance, Burnt}) ->
   Distance >= 0.0 andalso Burnt >= 0.0.
 
-%% Uncomment the following line to make the search faster.
-% weight(_, _, {call, _, travel, _}) -> 10;
+weight(_, _, {call, _, brake, _}) -> 2;
+weight(_, _, {call, _, travel, _}) -> 4;
 weight(_, _, _) -> 1.
 
 
@@ -402,7 +402,7 @@ prop_distance() ->
 %% `proper:quickcheck(car_fsm:prop_targeted_distance(), 1000).'
 prop_distance_targeted() ->
   ?FORALL_TARGETED(
-     Cmds, more_commands(2, proper_fsm:targeted_commands(?MODULE)),
+     Cmds, more_commands(3, proper_fsm:targeted_commands(?MODULE)),
      ?TRAPEXIT(
         begin
           start_link(),
@@ -413,10 +413,7 @@ prop_distance_targeted() ->
                           true -> 100 * Burnt / Distance;
                           false -> 0
                         end,
-          UV = case Consumption > ?CONSUMPTION of
-                 true -> Distance * 0.1;
-                 false -> Distance
-               end,
+          UV = Distance,
           ?MAXIMIZE(UV),
           ?WHENFAIL(
              io:format("Distance: ~p~nConsumption: ~p~n",
@@ -431,7 +428,7 @@ prop_distance_targeted() ->
 prop_distance_targeted_init() ->
   State = {initial_state(), initial_state_data()},
   ?FORALL_TARGETED(
-     Cmds, more_commands(2, proper_fsm:targeted_commands(?MODULE, State)),
+     Cmds, more_commands(3, proper_fsm:targeted_commands(?MODULE, State)),
      ?TRAPEXIT(
         begin
           start_link(),
@@ -442,10 +439,7 @@ prop_distance_targeted_init() ->
                           true -> 100 * Burnt / Distance;
                           false -> 0
                         end,
-          UV = case Consumption > ?CONSUMPTION of
-                 true -> Distance * 0.1;
-                 false -> Distance
-               end,
+          UV = Distance,
           ?MAXIMIZE(UV),
           ?WHENFAIL(
              io:format("Distance: ~p~nConsumption: ~p~n",

--- a/examples/car_statem.erl
+++ b/examples/car_statem.erl
@@ -144,7 +144,7 @@ handle_info(_Msg, S) ->
   {noreply, S}.
 
 terminate(_Reason, _S) ->
-  {ok}.
+  ok.
 
 code_change(_OldVsn, S, _Extra) ->
   {ok, S}.

--- a/examples/car_statem.erl
+++ b/examples/car_statem.erl
@@ -1,0 +1,422 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
+%%% Copyright 2010-2020 Manolis Papadakis <manopapad@gmail.com>,
+%%%                     Eirini Arvaniti <eirinibob@gmail.com>
+%%%                 and Kostis Sagonas <kostis@cs.ntua.gr>
+%%%
+%%% This file is part of PropEr.
+%%%
+%%% PropEr is free software: you can redistribute it and/or modify
+%%% it under the terms of the GNU General Public License as published by
+%%% the Free Software Foundation, either version 3 of the License, or
+%%% (at your option) any later version.
+%%%
+%%% PropEr is distributed in the hope that it will be useful,
+%%% but WITHOUT ANY WARRANTY; without even the implied warranty of
+%%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%%% GNU General Public License for more details.
+%%%
+%%% You should have received a copy of the GNU General Public License
+%%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
+
+%%% @copyright 2010-2020 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
+%%% @version {@version}
+%%% @author Spiros Dontas
+
+-module(car_statem).
+-behaviour(gen_server).
+-behaviour(proper_statem).
+
+-include_lib("proper/include/proper.hrl").
+
+
+%% -----------------------------------------------------------------------------
+%% Definitions
+%% -----------------------------------------------------------------------------
+
+
+-define(DISTANCE, 1000).
+-define(CONSUMPTION, 10).
+-define(HOUR, 3600).
+-define(ACCELERATION, 5).
+-define(DECELERATION, 20).
+-define(MAX_FUEL, 70).
+-define(MAX_SPEED, 200).
+-define(AVG(X), lists:sum(X) / length(X)).
+-define(NAME, car).
+
+
+%% -----------------------------------------------------------------------------
+%% Exports
+%% -----------------------------------------------------------------------------
+
+
+%% api
+-export([start_link/0, stop/0, accelerate/1, brake/1, travel/1, refuel/1]).
+%% gen_server
+-export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2,
+         code_change/3]).
+%% proper_statem
+-export([initial_state/0, command/1, precondition/2, postcondition/3,
+         next_state/3, all_commands/1, weight/1]).
+%% properties
+-export([prop_distance/0, prop_distance_targeted/0,
+         prop_distance_targeted_init/0]).
+
+
+%% -----------------------------------------------------------------------------
+%% Records
+%% -----------------------------------------------------------------------------
+
+
+-record(gen_state,
+        {fuel  :: float(),
+         speed :: non_neg_integer()}).
+
+-record(state,
+        {fuel     :: float(),
+         speed    :: non_neg_integer(),
+         distance :: float(),
+         burnt    :: float()}).
+
+
+%% -----------------------------------------------------------------------------
+%% API
+%% -----------------------------------------------------------------------------
+
+
+start_link() ->
+  gen_server:start_link({local, ?NAME}, ?MODULE, [], []).
+
+stop() ->
+  gen_server:stop(?NAME).
+
+accelerate(Value) ->
+  gen_server:call(?NAME, {accelerate, Value}).
+
+brake(Value) ->
+  gen_server:call(?NAME, {brake, Value}).
+
+travel(Distance) ->
+  gen_server:call(?NAME, {travel, Distance}).
+
+refuel(Amount) ->
+  gen_server:call(?NAME, {refuel, Amount}).
+
+
+%% -----------------------------------------------------------------------------
+%% gen_server callbacks
+%% -----------------------------------------------------------------------------
+
+
+init([]) ->
+  {ok, #gen_state{fuel = ?MAX_FUEL, speed = 0}}.
+
+handle_call({accelerate, Value}, _From, S) ->
+  #gen_state{fuel = Fuel, speed = Speed} = S,
+  {Distance, Acceleration, Burnt} =
+    acceleration_calculations({Speed, Value}, Fuel),
+  {reply, {Distance, Burnt}, S#gen_state{fuel = Fuel - Burnt,
+                                         speed = Speed + Acceleration}};
+
+handle_call({brake, Value}, _From, S) ->
+  #gen_state{fuel = Fuel, speed = Speed} = S,
+  {Distance, Deceleration, Burnt} =
+    acceleration_calculations({Speed, -Value}, Fuel),
+  {reply, {Distance, Burnt}, S#gen_state{fuel = Fuel - Burnt,
+                                         speed = Speed + Deceleration}};
+
+handle_call({travel, Distance}, _From, S) ->
+  #gen_state{fuel = Fuel, speed = Speed} = S,
+  {RealDistance, Burnt} = travel_calculations(Distance, Speed, Fuel),
+  {reply, {RealDistance, Burnt}, S#gen_state{fuel = Fuel - Burnt}};
+
+handle_call({refuel, Amount}, _From, S) ->
+  #gen_state{fuel = Fuel, speed = Speed} = S,
+  {Distance, _Deceleration, Burnt} =
+    acceleration_calculations({Speed, -Speed}, Fuel),
+  {reply, {Distance, Burnt}, S#gen_state{fuel = Fuel - Burnt + Amount,
+                                         speed = 0}}.
+
+handle_cast(_Msg, S) ->
+  {noreply, S}.
+
+handle_info(_Msg, S) ->
+  {noreply, S}.
+
+terminate(_Reason, _S) ->
+  {ok}.
+
+code_change(_OldVsn, S, _Extra) ->
+  {ok, S}.
+
+
+%% -----------------------------------------------------------------------------
+%% Generators
+%% -----------------------------------------------------------------------------
+
+
+accelerator(Speed) ->
+  integer(1, ?MAX_SPEED - Speed).
+
+braker(Speed) ->
+  integer(1, Speed).
+
+traveler() ->
+  integer(1, 100).
+
+refueler(Fuel) ->
+  integer(0, round(?MAX_FUEL - Fuel)).
+
+
+%% -----------------------------------------------------------------------------
+%% proper_statem callbacks
+%% -----------------------------------------------------------------------------
+
+
+initial_state() ->
+  #state{fuel     = ?MAX_FUEL,
+         speed    = 0,
+         burnt    = 0,
+         distance = 0}.
+
+command(S) ->
+  oneof(all_commands(S)).
+
+all_commands(S) ->
+  #state{fuel = Fuel, speed = Speed} = S,
+  [{call, ?MODULE, accelerate, [accelerator(Speed)]} || Speed < ?MAX_SPEED] ++
+    [{call, ?MODULE, brake, [braker(Speed)]} || Speed > 1] ++
+    [{call, ?MODULE, travel, [traveler()]}] ++
+    [{call, ?MODULE, refuel, [refueler(Fuel)]} || Fuel < ?MAX_FUEL].
+
+precondition(#state{fuel = Fuel, speed = Speed}, {call, _, accelerate, _}) ->
+  Fuel > ?MAX_FUEL * 0.1 andalso Speed < 200;
+precondition(#state{speed = Speed}, {call, _, brake, _}) ->
+  Speed > 0;
+precondition(#state{speed = Speed}, {call, _, travel, _}) ->
+  Speed > 20;
+precondition(#state{fuel = Fuel}, {call, _, refuel, _}) ->
+  Fuel < ?MAX_FUEL * 0.8;
+precondition(_, _) ->
+  true.
+
+postcondition(_S, _, {Distance, Burnt}) ->
+  Distance >= 0.0 andalso Burnt >= 0.0.
+
+next_state(S, _V, {call, _, accelerate, [Value]}) ->
+  #state{fuel = Fuel,
+         speed = Speed,
+         distance = Distance,
+         burnt = B} = S,
+  {Travelled, Acceleration, Burnt} =
+    acceleration_calculations({Speed, Value}, Fuel),
+  S#state{fuel = Fuel - Burnt,
+          speed = Speed + Acceleration,
+          distance = Distance + Travelled,
+          burnt = B + Burnt};
+next_state(S, _V, {call, _, brake, [Value]}) ->
+  #state{fuel = Fuel,
+         speed = Speed,
+         distance = Distance,
+         burnt = B} = S,
+  {Travelled, Acceleration, Burnt} =
+    acceleration_calculations({Speed, -Value}, Fuel),
+  S#state{fuel = Fuel - Burnt,
+          speed = Speed + Acceleration,
+          distance = Distance + Travelled,
+          burnt = B + Burnt};
+next_state(S, _V, {call, _, travel, [Value]}) ->
+  #state{fuel = Fuel,
+         speed = Speed,
+         distance = Distance,
+         burnt = B} = S,
+  {Travelled, Burnt} = travel_calculations(Value, Speed, Fuel),
+  S#state{fuel = Fuel - Burnt,
+          distance = Distance + Travelled,
+          burnt = B + Burnt};
+next_state(S, _V, {call, _, refuel, [Amount]}) ->
+  #state{fuel = Fuel,
+         speed = Speed,
+         distance = Distance,
+         burnt = B} = S,
+  {Travelled, Acceleration, Burnt} =
+    acceleration_calculations({Speed, -Speed}, Fuel),
+  S#state{fuel = Fuel - Burnt + Amount,
+          speed = Speed + Acceleration,
+          distance = Distance + Travelled,
+          burnt = B + Burnt}.
+
+%% Uncomment the following line to make the search faster.
+% weight(travel) -> 5;
+weight(_) -> 1.
+
+%% -----------------------------------------------------------------------------
+%% Properties
+%% -----------------------------------------------------------------------------
+
+
+%% This should "never" fail:
+%% `proper:quickcheck(car_statem:prop_normal_distance(), 1000).'
+prop_distance() ->
+  ?FORALL(Cmds, commands(?MODULE),
+          ?TRAPEXIT(
+             begin
+               start_link(),
+               {_H, S, R} = run_commands(?MODULE, Cmds),
+               stop(),
+               #state{distance = Distance, burnt = Burnt} = S,
+               Consumption = case Distance > 0 of
+                               true -> 100 * Burnt / Distance;
+                               false -> 0
+                             end,
+               ?WHENFAIL(
+                  io:format("Distance: ~p~nConsumption: ~p~n",
+                            [Distance, Consumption]),
+                  aggregate(command_names(Cmds),
+                            R =:= ok andalso (Distance < ?DISTANCE orelse
+                                              Consumption > ?CONSUMPTION)))
+             end)).
+
+
+%% This should fail most of the times with:<br/>
+%% `proper:quickcheck(car_fsm:prop_targeted_distance(), 1000).'
+prop_distance_targeted() ->
+  ?FORALL_TARGETED(Cmds, targeted_commands(?MODULE),
+                   ?TRAPEXIT(
+                      begin
+                        start_link(),
+                        {_H, S, R} = run_commands(?MODULE, Cmds),
+                        stop(),
+                        #state{distance = Distance, burnt = Burnt} = S,
+                        Consumption = case Distance > 0 of
+                                        true -> 100 * Burnt / Distance;
+                                        false -> 0
+                                      end,
+                        UV = case Consumption > ?CONSUMPTION of
+                               true -> Distance * 0.1;
+                               false -> Distance
+                             end,
+                        ?MAXIMIZE(UV),
+                        ?WHENFAIL(
+                           io:format("Distance: ~p~nConsumption: ~p~n",
+                                     [Distance, Consumption]),
+                           aggregate(command_names(Cmds),
+                                     R =:= ok andalso (Distance < ?DISTANCE orelse
+                                                       Consumption > ?CONSUMPTION)))
+                      end)).
+
+%% This should fail most of the times with:<br/>
+%% `proper:quickcheck(car_fsm:prop_targeted_distance_init(), 1000).'
+prop_distance_targeted_init() ->
+  State = initial_state(),
+  ?FORALL_TARGETED(Cmds, targeted_commands(?MODULE, State),
+                   ?TRAPEXIT(
+                      begin
+                        start_link(),
+                        {_H, S, R} = run_commands(?MODULE, Cmds),
+                        stop(),
+                        #state{distance = Distance, burnt = Burnt} = S,
+                        Consumption = case Distance > 0 of
+                                        true -> 100 * Burnt / Distance;
+                                        false -> 0
+                                      end,
+                        UV = case Consumption > ?CONSUMPTION of
+                               true -> Distance * 0.1;
+                               false -> Distance
+                             end,
+                        ?MAXIMIZE(UV),
+                        ?WHENFAIL(
+                           io:format("Distance: ~p~nConsumption: ~p~n",
+                                     [Distance, Consumption]),
+                           aggregate(command_names(Cmds),
+                                     R =:= ok andalso (Distance < ?DISTANCE orelse
+                                                       Consumption > ?CONSUMPTION)))
+                      end)).
+
+%% -----------------------------------------------------------------------------
+%% Calculation Functions
+%% -----------------------------------------------------------------------------
+
+
+travel_calculations(Distance, Speed, Fuel) when Speed > 0 ->
+  Consumption = fuel_consumption(Speed),
+  Burn = Consumption * Distance / 100,
+  case Burn > Fuel of
+    true -> {Fuel * 100 / Consumption, Fuel};
+    false -> {Distance, Burn}
+  end;
+travel_calculations(_D, _S, _F) ->
+  {0, 0.0}.
+
+acceleration_calculations({Speed, Accel}, Fuel) when Accel > 0 ->
+  Acceleration = case Speed + Accel > ?MAX_SPEED of
+                   true -> ?MAX_SPEED - Speed;
+                   false -> Accel
+                 end,
+  Consumption = fuel_consumption(Speed, Acceleration),
+  Distance = calculate_distance(Speed, Acceleration),
+  Burn = Consumption * Distance / 100,
+  case Burn > Fuel of
+    true -> acceleration_calculations({Speed, Acceleration - ?ACCELERATION},
+                                      Fuel);
+    false -> {Distance, Acceleration, Burn}
+  end;
+acceleration_calculations({Speed, Accel}, Fuel) ->
+  Acceleration = case Speed + Accel < 0 of
+                   true -> -Speed;
+                   false -> Accel
+                 end,
+  Consumption = fuel_consumption(Speed, Acceleration),
+  Distance = calculate_distance(Speed, Acceleration),
+  Burn = Consumption * Distance / 100,
+  case Burn > Fuel of
+    true -> {Distance, Acceleration, Fuel};
+    false -> {Distance, Acceleration, Burn}
+  end.
+
+
+%% -----------------------------------------------------------------------------
+%% Helpers
+%% -----------------------------------------------------------------------------
+
+
+%% Calculate distance driven when accelerating - decelerating.
+calculate_distance(Speed, Acceleration) when Acceleration > 0 ->
+  T = Acceleration / ?ACCELERATION,
+  Speed / ?HOUR * T + 1 / 2 * ?ACCELERATION / ?HOUR * T * T;
+calculate_distance(Speed, Acceleration)->
+  T = -Acceleration / ?DECELERATION,
+  Speed / ?HOUR * T - 1 / 2 * ?DECELERATION / ?HOUR * T * T.
+
+%% Low speeds give rewards to consumption.
+%% High speed give penalty to consumption.
+fuel_speed_penalty(Speed) when Speed =< 50 -> 0.7;
+fuel_speed_penalty(Speed) when Speed =< 100 -> 0.9;
+fuel_speed_penalty(Speed) when Speed =< 150 -> 1.1;
+fuel_speed_penalty(_) -> 1.5.
+
+%% Acceleration penalty.
+%% Deceleration reward.
+fuel_acceleration_penalty(Acceleration) when Acceleration > 0 -> 2.0;
+fuel_acceleration_penalty(_) -> 0.1.
+
+%% Fuel Consumption (stable speed).
+fuel_consumption(Speed) ->
+  Speed * fuel_speed_penalty(Speed) / 10.
+
+%% Fuel Consumption (acc - dec).
+fuel_consumption(Speed, Acceleration) ->
+  Consumptions = [fuel_consumption(S) *
+                    fuel_acceleration_penalty(Acceleration)
+                  || S <- intermediate_speeds(Speed, Acceleration)],
+  ?AVG(Consumptions).
+
+%% Intermediate speeds from accelerating - decelerating.
+intermediate_speeds(Speed, Acceleration) when Acceleration > 0 ->
+  T = Acceleration / ?ACCELERATION,
+  [Speed + X / 10 * ?ACCELERATION || X <- lists:seq(0, round(T * 10))];
+intermediate_speeds(Speed, Acceleration) ->
+  T = -Acceleration / ?DECELERATION,
+  [Speed - X / 10 * ?DECELERATION || X <- lists:seq(0, round(T * 10))].

--- a/examples/car_statem.erl
+++ b/examples/car_statem.erl
@@ -245,8 +245,8 @@ next_state(S, _V, {call, _, refuel, [Amount]}) ->
           distance = Distance + Travelled,
           burnt = B + Burnt}.
 
-%% Uncomment the following line to make the search faster.
-% weight(travel) -> 5;
+weight(brake) -> 2;
+weight(travel) -> 4;
 weight(_) -> 1.
 
 
@@ -282,7 +282,7 @@ prop_distance() ->
 %% `proper:quickcheck(car_fsm:prop_targeted_distance(), 1000).'
 prop_distance_targeted() ->
   ?FORALL_TARGETED(
-     Cmds, targeted_commands(?MODULE),
+     Cmds, more_commands(2, targeted_commands(?MODULE)),
      ?TRAPEXIT(
         begin
           start_link(),
@@ -293,10 +293,7 @@ prop_distance_targeted() ->
                           true -> 100 * Burnt / Distance;
                           false -> 0
                         end,
-          UV = case Consumption > ?CONSUMPTION of
-                 true -> Distance * 0.1;
-                 false -> Distance
-               end,
+          UV = Distance,
           ?MAXIMIZE(UV),
           ?WHENFAIL(
              io:format("Distance: ~p~nConsumption: ~p~n",
@@ -311,7 +308,7 @@ prop_distance_targeted() ->
 prop_distance_targeted_init() ->
   State = initial_state(),
   ?FORALL_TARGETED(
-     Cmds, targeted_commands(?MODULE, State),
+     Cmds, more_commands(2, targeted_commands(?MODULE, State)),
      ?TRAPEXIT(
         begin
           start_link(),
@@ -322,10 +319,7 @@ prop_distance_targeted_init() ->
                           true -> 100 * Burnt / Distance;
                           false -> 0
                         end,
-          UV = case Consumption > ?CONSUMPTION of
-                 true -> Distance * 0.1;
-                 false -> Distance
-               end,
+          UV = Distance,
           ?MAXIMIZE(UV),
           ?WHENFAIL(
              io:format("Distance: ~p~nConsumption: ~p~n",

--- a/examples/car_statem.erl
+++ b/examples/car_statem.erl
@@ -1,7 +1,7 @@
 %%% -*- coding: utf-8 -*-
 %%% -*- erlang-indent-level: 2 -*-
 %%% -------------------------------------------------------------------
-%%% Copyright 2010-2020 Manolis Papadakis <manopapad@gmail.com>,
+%%% Copyright 2020-     Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>
 %%%
@@ -20,7 +20,7 @@
 %%% You should have received a copy of the GNU General Public License
 %%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
 
-%%% @copyright 2010-2020 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
+%%% @copyright 2020 Spiros Dontas and Kostis Sagonas
 %%% @version {@version}
 %%% @author Spiros Dontas
 
@@ -60,9 +60,6 @@
 %% proper_statem
 -export([initial_state/0, command/1, precondition/2, postcondition/3,
          next_state/3, all_commands/1, weight/1]).
-%% properties
--export([prop_distance/0, prop_distance_targeted/0,
-         prop_distance_targeted_init/0]).
 
 
 %% -----------------------------------------------------------------------------
@@ -252,6 +249,7 @@ next_state(S, _V, {call, _, refuel, [Amount]}) ->
 % weight(travel) -> 5;
 weight(_) -> 1.
 
+
 %% -----------------------------------------------------------------------------
 %% Properties
 %% -----------------------------------------------------------------------------
@@ -283,57 +281,59 @@ prop_distance() ->
 %% This should fail most of the times with:<br/>
 %% `proper:quickcheck(car_fsm:prop_targeted_distance(), 1000).'
 prop_distance_targeted() ->
-  ?FORALL_TARGETED(Cmds, targeted_commands(?MODULE),
-                   ?TRAPEXIT(
-                      begin
-                        start_link(),
-                        {_H, S, R} = run_commands(?MODULE, Cmds),
-                        stop(),
-                        #state{distance = Distance, burnt = Burnt} = S,
-                        Consumption = case Distance > 0 of
-                                        true -> 100 * Burnt / Distance;
-                                        false -> 0
-                                      end,
-                        UV = case Consumption > ?CONSUMPTION of
-                               true -> Distance * 0.1;
-                               false -> Distance
-                             end,
-                        ?MAXIMIZE(UV),
-                        ?WHENFAIL(
-                           io:format("Distance: ~p~nConsumption: ~p~n",
-                                     [Distance, Consumption]),
-                           aggregate(command_names(Cmds),
-                                     R =:= ok andalso (Distance < ?DISTANCE orelse
-                                                       Consumption > ?CONSUMPTION)))
-                      end)).
+  ?FORALL_TARGETED(
+     Cmds, targeted_commands(?MODULE),
+     ?TRAPEXIT(
+        begin
+          start_link(),
+          {_H, S, R} = run_commands(?MODULE, Cmds),
+          stop(),
+          #state{distance = Distance, burnt = Burnt} = S,
+          Consumption = case Distance > 0 of
+                          true -> 100 * Burnt / Distance;
+                          false -> 0
+                        end,
+          UV = case Consumption > ?CONSUMPTION of
+                 true -> Distance * 0.1;
+                 false -> Distance
+               end,
+          ?MAXIMIZE(UV),
+          ?WHENFAIL(
+             io:format("Distance: ~p~nConsumption: ~p~n",
+                       [Distance, Consumption]),
+             aggregate(command_names(Cmds),
+                       R =:= ok andalso (Distance < ?DISTANCE orelse
+                                         Consumption > ?CONSUMPTION)))
+        end)).
 
 %% This should fail most of the times with:<br/>
 %% `proper:quickcheck(car_fsm:prop_targeted_distance_init(), 1000).'
 prop_distance_targeted_init() ->
   State = initial_state(),
-  ?FORALL_TARGETED(Cmds, targeted_commands(?MODULE, State),
-                   ?TRAPEXIT(
-                      begin
-                        start_link(),
-                        {_H, S, R} = run_commands(?MODULE, Cmds),
-                        stop(),
-                        #state{distance = Distance, burnt = Burnt} = S,
-                        Consumption = case Distance > 0 of
-                                        true -> 100 * Burnt / Distance;
-                                        false -> 0
-                                      end,
-                        UV = case Consumption > ?CONSUMPTION of
-                               true -> Distance * 0.1;
-                               false -> Distance
-                             end,
-                        ?MAXIMIZE(UV),
-                        ?WHENFAIL(
-                           io:format("Distance: ~p~nConsumption: ~p~n",
-                                     [Distance, Consumption]),
-                           aggregate(command_names(Cmds),
-                                     R =:= ok andalso (Distance < ?DISTANCE orelse
-                                                       Consumption > ?CONSUMPTION)))
-                      end)).
+  ?FORALL_TARGETED(
+     Cmds, targeted_commands(?MODULE, State),
+     ?TRAPEXIT(
+        begin
+          start_link(),
+          {_H, S, R} = run_commands(?MODULE, Cmds),
+          stop(),
+          #state{distance = Distance, burnt = Burnt} = S,
+          Consumption = case Distance > 0 of
+                          true -> 100 * Burnt / Distance;
+                          false -> 0
+                        end,
+          UV = case Consumption > ?CONSUMPTION of
+                 true -> Distance * 0.1;
+                 false -> Distance
+               end,
+          ?MAXIMIZE(UV),
+          ?WHENFAIL(
+             io:format("Distance: ~p~nConsumption: ~p~n",
+                       [Distance, Consumption]),
+             aggregate(command_names(Cmds),
+                       R =:= ok andalso (Distance < ?DISTANCE orelse
+                                         Consumption > ?CONSUMPTION)))
+        end)).
 
 %% -----------------------------------------------------------------------------
 %% Calculation Functions

--- a/include/proper.hrl
+++ b/include/proper.hrl
@@ -94,6 +94,7 @@
 
 -import(proper_statem, [commands/1, commands/2, parallel_commands/1,
 			parallel_commands/2, more_commands/2]).
+-import(proper_statem, [targeted_commands/1, targeted_commands/2]).
 -import(proper_statem, [run_commands/2, run_commands/3,  state_after/2,
 			command_names/1, zip/2, run_parallel_commands/2,
 			run_parallel_commands/3]).

--- a/src/proper_fsm.erl
+++ b/src/proper_fsm.erl
@@ -376,9 +376,9 @@ targeted_commands_gen(Mod, {Name, Data} = InitialState) ->
 
 -spec next_commands_gen(mod_name()) -> next_fun().
 next_commands_gen(Mod) ->
-  fun ({Weights, _Cmds}, {_D, _T}) ->
+  fun ({Weights, _Cmds}, {_D, T}) ->
       State = initial_state(Mod),
-      NewWeights = proper_statem:next_weights(Weights),
+      NewWeights = proper_statem:next_weights(Weights, T),
       CmdsGen = ?LET([_ | Cmds],
                      proper_statem:next_gen(?MODULE, NewWeights, State),
                      Cmds),
@@ -390,9 +390,9 @@ next_commands_gen(Mod) ->
 
 -spec next_commands_gen(mod_name(), fsm_state()) -> next_fun().
 next_commands_gen(Mod, {Name, Data} = InitialState) ->
-  fun ({Weights, _Cmds}, {_D, _T}) ->
+  fun ({Weights, _Cmds}, {_D, T}) ->
       State = #state{name = Name, data = Data, mod = Mod},
-      NewWeights = proper_statem:next_weights(Weights),
+      NewWeights = proper_statem:next_weights(Weights, T),
       CmdsGen = ?LET([_ | Cmds],
                      proper_statem:next_gen(?MODULE, NewWeights, State),
                      [{init, InitialState} | Cmds]),

--- a/src/proper_fsm.erl
+++ b/src/proper_fsm.erl
@@ -150,7 +150,7 @@
 %%%
 %%% == Stateful Targeted Testing ==
 %%% During testing of the system's behavior, there may be some failing command
-%%% sequencies that the default property based testing does not find with ease,
+%%% sequences that the random property based testing does not find with ease,
 %%% or at all. In these cases, stateful targeted property based testing can help
 %%% find such edge cases, provided a utility value.
 %%%

--- a/src/proper_fsm.erl
+++ b/src/proper_fsm.erl
@@ -455,15 +455,13 @@ finalize_weights(InitialState, Cmds, Weights) ->
           fun ({To, {call, _M, Call, _A} = SC}, Acc) ->
               RealTo = cook_history(From, To),
               Key = {From, RealTo, Call},
+              W = case is_exported(Mod, {weight, 3}) of
+                    true -> Mod:weight(From, RealTo, SC);
+                    false -> 1
+                  end,
               case maps:is_key(Key, Acc) of
                 true -> Acc;
-                false ->
-                  case is_exported(Mod, {weight, 3}) of
-                    true ->
-                      maps:put(Key, Mod:weight(From, RealTo, SC), Acc);
-                    false ->
-                      maps:put(Key, 1, Acc)
-                  end
+                false -> maps:put(Key, W, Acc)
               end
           end,
         NextState = next_state(State, Var, SymbCall),

--- a/src/proper_fsm.erl
+++ b/src/proper_fsm.erl
@@ -147,6 +147,26 @@
 %%%                    cleanup(),
 %%%                    Result =:= ok
 %%%                end).'''
+%%%
+%%% == Targeted Testing ==
+%%% During testing of the system's behavior, there may be some failing command
+%%% sequencies that the default property based testing does not find with ease,
+%%% or at all. In these cases, targeted property based testing can help find
+%%% such edge cases, provided a utility value.
+%%%
+%%% ```prop_targeted_testing() ->
+%%%        ?FORALL_TARGETED(Cmds, proper_fsm:targeted_commands(?MODULE),
+%%%                         begin
+%%%                             {History, State, Result} = proper_fsm:run_commands(?MODULE, Cmds),
+%%%                             UV = uv(History, State, Result),
+%%%                             ?MAXIMIZE(UV),
+%%%                             cleanup(),
+%%%                             Result =:= ok
+%%%                         end).'''
+%%%
+%%% Please note that the `UV' value can be computed in any way fit, depending
+%%% on the use case. `uv' is used here as a dummy function which computes the
+%%% utility value.
 %%% @end
 
 -module(proper_fsm).
@@ -154,9 +174,9 @@
 -export([commands/1, commands/2, run_commands/2, run_commands/3,
 	 state_names/1]).
 -export([targeted_commands/1, targeted_commands/2]).
--export([command/1, precondition/2, next_state/3, postcondition/3,
-         all_commands/1]).
+-export([command/1, precondition/2, next_state/3, postcondition/3]).
 -export([target_states/4]).
+%% Exported for PropEr internal usage.
 -export([select_command/2]).
 
 -include("proper_internal.hrl").
@@ -349,11 +369,6 @@ next_state(S = #state{name = From, data = Data, mod = Mod} , Var, Call) ->
 postcondition(#state{name = From, data = Data, mod = Mod}, Call, Res) ->
     To = cook_history(From, transition_target(Mod, From, Data, Call)),
     Mod:postcondition(From, To, Data, Call, Res).
-
-%% @private
--spec all_commands(state()) -> [symbolic_call()].
-all_commands(#state{name = From, data = Data, mod = Mod}) ->
-  [CallGen || {_, CallGen} <- get_transitions(Mod, From, Data)].
 
 
 %% -----------------------------------------------------------------------------

--- a/src/proper_gen_next.erl
+++ b/src/proper_gen_next.erl
@@ -28,7 +28,7 @@
 -export([init/0, cleanup/0, from_proper_generator/1,
 	 match/3, set_matcher/2, set_user_nf/2, update_caches/1]).
 
--export_type([matcher/0, temperature/0, nf/0]).
+-export_type([matcher/0, temperature/0, depth/0, nf/0]).
 
 -include("proper_internal.hrl").
 

--- a/src/proper_sa.erl
+++ b/src/proper_sa.erl
@@ -257,7 +257,7 @@ temperature_function_standard_sa(_OldTemperature,
                                  K_Max,
                                  K_Current,
                                  _Accepted) ->
-  {1.0 - (K_Current / K_Max), K_Current + 1}.
+  {1.0 - min(1, K_Current / K_Max), K_Current + 1}.
 
 get_temperature_function() ->
   case get(proper_sa_tempfunc) of

--- a/src/proper_statem.erl
+++ b/src/proper_statem.erl
@@ -222,7 +222,7 @@
 %%%
 %%% == Stateful Targeted Testing ==
 %%% During testing of the system's behavior, there may be some failing command
-%%% sequencies that the default property based testing does not find with ease,
+%%% sequences that the random property based testing does not find with ease,
 %%% or at all. In these cases, stateful targeted property based testing can help
 %%% find such edge cases, provided a utility value.
 %%%
@@ -244,7 +244,7 @@
 -module(proper_statem).
 
 -export([commands/1, commands/2, parallel_commands/1, parallel_commands/2,
-	       targeted_commands/1, targeted_commands/2, more_commands/2]).
+         targeted_commands/1, targeted_commands/2, more_commands/2]).
 -export([run_commands/2, run_commands/3, run_parallel_commands/2,
 	 run_parallel_commands/3]).
 -export([state_after/2, command_names/1, zip/2]).

--- a/src/proper_statem.erl
+++ b/src/proper_statem.erl
@@ -1253,5 +1253,5 @@ get_commands_frequency(RawType) ->
   Env = proper_types:get_prop(env, Type),
   SubEnv = proper_types:get_prop(subenv, Type),
   Cmds = lists:flatmap(fun get_commands_tuple/1, Env),
-  Freqs = lists:map(fun (X) -> element(1, X) end, SubEnv),
+  Freqs = [element(1, X) || X <- SubEnv],
   lists:zip(Freqs, Cmds).

--- a/src/proper_target.erl
+++ b/src/proper_target.erl
@@ -97,7 +97,8 @@
 -record(state,
         {strategy           :: strategy(),
          target = undefined :: target_state() | undefined,
-         data = undefined   :: strategy_data() | undefined}).
+         data = undefined   :: strategy_data() | undefined,
+         stateful = false   :: boolean()}).
 -type state() :: #state{}.
 
 -export_type([strategy/0, fitness/0, search_steps/0]).
@@ -137,7 +138,8 @@ init_strategy(#{search_steps := Steps, search_strategy := Strat}) ->
   Strategy = strategy(Strat),
   proper_gen_next:init(),
   Data = Strategy:init_strategy(Steps),
-  {ok, TargetserverPid} = gen_server:start_link(?MODULE, [{Strategy, Data}], []),
+  Args = [{Strategy, Data}],
+  {ok, TargetserverPid} = gen_server:start_link(?MODULE, Args, []),
   put('$targetserver_pid', TargetserverPid),
   update_pdict(),
   ok.
@@ -152,6 +154,7 @@ cleanup_strategy() ->
       proper_gen_next:cleanup(),
       gen_server:stop(TargetserverPid)
   end.
+
 
 %% This is used to create the targeted generator.
 
@@ -189,8 +192,21 @@ update_pdict([Key | Keys], KVs) ->
 init_target(RawType) ->
   update_pdict(['$left', '$size']),
   Type = proper_types:cook_outer(RawType),
+  case proper_types:find_prop(is_user_nf_stateful, Type) of
+    {ok, true} -> init_stateful();
+    {ok, false} -> ok;
+    error -> ok
+  end,
   TargetserverPid = get('$targetserver_pid'),
   safe_call(TargetserverPid, {init_target, Type}).
+
+%% Initialize stateful configuration.
+
+%% @private
+-spec init_stateful() -> ok.
+init_stateful() ->
+  TargetserverPid = get('$targetserver_pid'),
+  safe_call(TargetserverPid, init_stateful).
 
 %% This produces the next gen instance from the next
 %% generator provided by the strategy. It will also
@@ -207,8 +223,9 @@ targeted_gen() ->
 
 -spec get_shrinker(proper_types:type()) -> proper_types:type().
 get_shrinker(Type) ->
-  TargetserverPid = get('$targetserver_pid'),
   try
+    update_pdict(['$left', '$size']),
+    TargetserverPid = get('$targetserver_pid'),
     gen_server:call(TargetserverPid, shrinker)
   catch
     _:{noproc, _} ->
@@ -268,6 +285,11 @@ strategy(Strat) ->
       Strat
   end.
 
+%% @private
+get_stateful_cmds({'$used', Used, {Weights, Cmds}})
+  when is_map(Weights) andalso is_list(Cmds) ->
+  get_stateful_cmds(Used);
+get_stateful_cmds(Cmds) -> Cmds.
 
 %% -----------------------------------------------------------------------------
 %% gen_server callbacks
@@ -285,7 +307,11 @@ init([{Strategy, Data}]) ->
 handle_call(gen, _From, State) ->
   #state{strategy = Strat, target = Target, data = Data} = State,
   {NextValue, NewTarget, NewData} = Strat:next(Target, Data),
-  {reply, NextValue, State#state{target = NewTarget, data = NewData}};
+  Ret = case State#state.stateful of
+          true -> get_stateful_cmds(NextValue);
+          false -> NextValue
+        end,
+  {reply, Ret, State#state{target = NewTarget, data = NewData}};
 
 handle_call(shrinker, _From, State) ->
   #state{strategy = Strat, target = Target, data = Data} = State,
@@ -301,6 +327,9 @@ handle_call({init_target, Type}, _From, State) ->
 handle_call({update_pdict, KVs}, _From, State) ->
   lists:foreach(fun ({K, V}) -> put(K, V) end, KVs),
   {reply, ok, State};
+
+handle_call(init_stateful, _From, State) ->
+  {reply, ok, State#state{stateful = true}};
 
 handle_call({update_fitness, Fitness}, _From, State) ->
   #state{strategy = Strat, target = Target, data = Data} = State,

--- a/src/proper_target.erl
+++ b/src/proper_target.erl
@@ -287,7 +287,7 @@ strategy(Strat) ->
 
 %% @private
 get_stateful_cmds({'$used', Used, {Weights, Cmds}})
-  when is_map(Weights) andalso is_list(Cmds) ->
+  when is_map(Weights), is_list(Cmds) ->
   get_stateful_cmds(Used);
 get_stateful_cmds(Cmds) -> Cmds.
 

--- a/src/proper_target.erl
+++ b/src/proper_target.erl
@@ -223,9 +223,8 @@ targeted_gen() ->
 
 -spec get_shrinker(proper_types:type()) -> proper_types:type().
 get_shrinker(Type) ->
+  TargetserverPid = get('$targetserver_pid'),
   try
-    update_pdict(['$left', '$size']),
-    TargetserverPid = get('$targetserver_pid'),
     gen_server:call(TargetserverPid, shrinker)
   catch
     _:{noproc, _} ->

--- a/src/proper_types.erl
+++ b/src/proper_types.erl
@@ -241,7 +241,7 @@
 			| 'get_length' | 'split' | 'join' | 'get_indices'
 			| 'remove' | 'retrieve' | 'update' | 'constraints'
 			| 'parameters' | 'env' | 'subenv'
-			| 'user_nf' | 'is_user_nf' | 'matcher'.
+			| 'user_nf' | 'is_user_nf' | 'is_user_nf_stateful' | 'matcher'.
 
 -type type_prop_value() :: term().
 -type type_prop() ::
@@ -291,7 +291,8 @@
     | {'env', term()}
     | {'subenv', term()}
     | {'user_nf', proper_gen_next:nf()}
-    | {'is_user_nf', boolean()}.
+    | {'is_user_nf', boolean()}
+    | {'is_user_nf_stateful', boolean()}.
 
 
 %%------------------------------------------------------------------------------

--- a/test/proper_tests.erl
+++ b/test/proper_tests.erl
@@ -1396,10 +1396,11 @@ sampleshrink_test_() ->
 
 examples_are_ok_test_() ->
     %% No need to test more in order to check that the examples work.
-    Opts = [{numtests,42}],
-    [{timeout, 42, ?_assertEqual([], proper:module(M, Opts))}
-     || M <- [b64,car_statem,car_fsm,elevator_fsm,ets_statem,mastermind,
-              pdict_statem,stack]].
+    TargetedOpts = [{numtests,10}],
+    [{timeout, 42, ?_assertEqual([], proper:module(M))}
+     || M <- [b64,elevator_fsm,ets_statem,mastermind,pdict_statem,stack]] ++
+      [{timeout, 42, ?_assertEqual([], proper:module(M, TargetedOpts))}
+       || M <- [car_statem, car_fsm]].
 
 %% test the properties of the `magic' example.
 example_magic_props_test_() ->

--- a/test/proper_tests.erl
+++ b/test/proper_tests.erl
@@ -1396,11 +1396,8 @@ sampleshrink_test_() ->
 
 examples_are_ok_test_() ->
     %% No need to test more in order to check that the examples work.
-    TargetedOpts = [{numtests,10}],
     [{timeout, 42, ?_assertEqual([], proper:module(M))}
-     || M <- [b64,elevator_fsm,ets_statem,mastermind,pdict_statem,stack]] ++
-      [{timeout, 42, ?_assertEqual([], proper:module(M, TargetedOpts))}
-       || M <- [car_statem, car_fsm]].
+     || M <- [b64,elevator_fsm,ets_statem,mastermind,pdict_statem,stack]].
 
 %% test the properties of the `magic' example.
 example_magic_props_test_() ->
@@ -1433,6 +1430,20 @@ example_mastermind_props_test_() ->
       ?_passes(mastermind:prop_secret_combination_is_not_discarded(simple))}
     |[{timeout, 10,
        ?_passes(mastermind:Prop(S))} || Prop <- Properties, S <- Strategies]].
+
+%% test the properties of `car_statem' example.
+example_car_statem_props_test_() ->
+  FailOpts = [{numtests,2000}, noshrink],
+  [?_passes(car_statem:prop_distance(), [500]),
+   {timeout, 42, ?_failsChk(car_statem:prop_distance_targeted(), FailOpts)},
+   {timeout, 42, ?_failsChk(car_statem:prop_distance_targeted_init(), FailOpts)}].
+
+%% test the properties of `car_fsm' example.
+example_car_fsm_props_test_() ->
+  FailOpts = [{numtests,2000}, noshrink],
+  [?_passes(car_fsm:prop_distance(), [500]),
+   {timeout, 42, ?_failsChk(car_fsm:prop_distance_targeted(), FailOpts)},
+   {timeout, 42, ?_failsChk(car_fsm:prop_distance_targeted_init(), FailOpts)}].
 
 %%------------------------------------------------------------------------------
 %% Performance tests

--- a/test/proper_tests.erl
+++ b/test/proper_tests.erl
@@ -1434,16 +1434,16 @@ example_mastermind_props_test_() ->
 %% test the properties of `car_statem' example.
 example_car_statem_props_test_() ->
   FailOpts = [{numtests,2000}, noshrink],
-  [?_passes(car_statem:prop_distance(), [500]),
-   {timeout, 42, ?_failsChk(car_statem:prop_distance_targeted(), FailOpts)},
-   {timeout, 42, ?_failsChk(car_statem:prop_distance_targeted_init(), FailOpts)}].
+  [{timeout, 42, ?_passes(car_statem:prop_distance(), [500])},
+   {timeout, 600, ?_failsChk(car_statem:prop_distance_targeted(), FailOpts)},
+   {timeout, 600, ?_failsChk(car_statem:prop_distance_targeted_init(), FailOpts)}].
 
 %% test the properties of `car_fsm' example.
 example_car_fsm_props_test_() ->
   FailOpts = [{numtests,2000}, noshrink],
-  [?_passes(car_fsm:prop_distance(), [500]),
-   {timeout, 42, ?_failsChk(car_fsm:prop_distance_targeted(), FailOpts)},
-   {timeout, 42, ?_failsChk(car_fsm:prop_distance_targeted_init(), FailOpts)}].
+  [{timeout, 42, ?_passes(car_fsm:prop_distance(), [500])},
+   {timeout, 600, ?_failsChk(car_fsm:prop_distance_targeted(), FailOpts)},
+   {timeout, 600, ?_failsChk(car_fsm:prop_distance_targeted_init(), FailOpts)}].
 
 %%------------------------------------------------------------------------------
 %% Performance tests

--- a/test/proper_tests.erl
+++ b/test/proper_tests.erl
@@ -1432,15 +1432,15 @@ example_mastermind_props_test_() ->
 
 %% test the properties of `car_statem' example.
 example_car_statem_props_test_() ->
-  FailOpts = [{numtests,2000}, noshrink],
-  [{timeout, 42, ?_passes(car_statem:prop_distance(), [500])},
+  FailOpts = [{numtests,10000}, {max_size,50}, {constraint_tries,1000}, noshrink],
+  [{timeout, 42, ?_passes(car_statem:prop_distance(), [500, {max_size,50}])},
    {timeout, 600, ?_failsChk(car_statem:prop_distance_targeted(), FailOpts)},
    {timeout, 600, ?_failsChk(car_statem:prop_distance_targeted_init(), FailOpts)}].
 
 %% test the properties of `car_fsm' example.
 example_car_fsm_props_test_() ->
-  FailOpts = [{numtests,2000}, noshrink],
-  [{timeout, 42, ?_passes(car_fsm:prop_distance(), [500])},
+  FailOpts = [{numtests,10000}, {max_size,100}, {constraint_tries,500}, noshrink],
+  [{timeout, 42, ?_passes(car_fsm:prop_distance(), [500, {max_size,100}])},
    {timeout, 600, ?_failsChk(car_fsm:prop_distance_targeted(), FailOpts)},
    {timeout, 600, ?_failsChk(car_fsm:prop_distance_targeted_init(), FailOpts)}].
 

--- a/test/proper_tests.erl
+++ b/test/proper_tests.erl
@@ -1395,8 +1395,11 @@ sampleshrink_test_() ->
 %%------------------------------------------------------------------------------
 
 examples_are_ok_test_() ->
-    [{timeout, 42, ?_assertEqual([], proper:module(M))}
-     || M <- [b64,elevator_fsm,ets_statem,mastermind,pdict_statem,stack]].
+    %% No need to test more in order to check that the examples work.
+    Opts = [{numtests,42}],
+    [{timeout, 42, ?_assertEqual([], proper:module(M, Opts))}
+     || M <- [b64,car_statem,car_fsm,elevator_fsm,ets_statem,mastermind,
+              pdict_statem,stack]].
 
 %% test the properties of the `magic' example.
 example_magic_props_test_() ->

--- a/test/proper_tests.erl
+++ b/test/proper_tests.erl
@@ -1395,7 +1395,6 @@ sampleshrink_test_() ->
 %%------------------------------------------------------------------------------
 
 examples_are_ok_test_() ->
-    %% No need to test more in order to check that the examples work.
     [{timeout, 42, ?_assertEqual([], proper:module(M))}
      || M <- [b64,elevator_fsm,ets_statem,mastermind,pdict_statem,stack]].
 

--- a/test/proper_tests.erl
+++ b/test/proper_tests.erl
@@ -1432,15 +1432,15 @@ example_mastermind_props_test_() ->
 
 %% test the properties of `car_statem' example.
 example_car_statem_props_test_() ->
-  FailOpts = [{numtests,10000}, {max_size,50}, {constraint_tries,1000}, noshrink],
-  [{timeout, 42, ?_passes(car_statem:prop_distance(), [500, {max_size,50}])},
+  FailOpts = [{numtests,1000}, {constraint_tries,1000}, noshrink],
+  [{timeout, 42, ?_passes(car_statem:prop_distance(), [500])},
    {timeout, 600, ?_failsChk(car_statem:prop_distance_targeted(), FailOpts)},
    {timeout, 600, ?_failsChk(car_statem:prop_distance_targeted_init(), FailOpts)}].
 
 %% test the properties of `car_fsm' example.
 example_car_fsm_props_test_() ->
-  FailOpts = [{numtests,10000}, {max_size,100}, {constraint_tries,500}, noshrink],
-  [{timeout, 42, ?_passes(car_fsm:prop_distance(), [500, {max_size,100}])},
+  FailOpts = [{numtests,1000}, {constraint_tries,1000}, noshrink],
+  [{timeout, 42, ?_passes(car_fsm:prop_distance(), [500])},
    {timeout, 600, ?_failsChk(car_fsm:prop_distance_targeted(), FailOpts)},
    {timeout, 600, ?_failsChk(car_fsm:prop_distance_targeted_init(), FailOpts)}].
 


### PR DESCRIPTION
This pull request aims to add a TPBT implementation for stateful systems (both `proper_statem` and `proper_fsm`). This is achieved by adding new `targeted_commands/1` and `targeted_commands/2` in both of those. These new commands should be used in conjuction with the `?FORALL_TARGETED` macro.

Examples can be found in the `examples/car_statem.erl` and `examples/car_fsm.erl` files. Both implement the same example, one as a `gen_server -> proper_statem` and one as a `gen_statem -> proper_fsm`.

The examples are also now included in PropEr's test suite, in order to check that everything works as expected. However, tests should be revisited in order to add some more unit testing in the functions added in `proper_statem` and `proper_fsm` respectively.