### PR TITLE
Refactor stateful TPBT

### DIFF
--- a/examples/car_fsm.erl
+++ b/examples/car_fsm.erl
@@ -326,7 +326,7 @@ brake_commands(Speed) ->
 %% Vanilla property based testing. This should not fail consistently.
 prop_distance() ->
   ?FORALL(
-     Cmds, more_commands(2, proper_fsm:commands(?MODULE)),
+     Cmds, proper_fsm:commands(?MODULE),
      ?TRAPEXIT(
         begin
           start_link(),
@@ -342,7 +342,7 @@ prop_distance() ->
 %% provides failing command sequencies more consistently.
 prop_distance_targeted() ->
   ?FORALL_TARGETED(
-     Cmds, more_commands(2, proper_fsm:targeted_commands(?MODULE)),
+     Cmds, proper_fsm:targeted_commands(?MODULE),
      ?TRAPEXIT(
         begin
           start_link(),
@@ -360,7 +360,7 @@ prop_distance_targeted() ->
 prop_distance_targeted_init() ->
   State = {initial_state(), initial_state_data()},
   ?FORALL_TARGETED(
-     Cmds, more_commands(2, proper_fsm:targeted_commands(?MODULE, State)),
+     Cmds, proper_fsm:targeted_commands(?MODULE, State),
      ?TRAPEXIT(
         begin
           start_link(),

--- a/examples/car_statem.erl
+++ b/examples/car_statem.erl
@@ -51,7 +51,7 @@
 %% -----------------------------------------------------------------------------
 
 
--define(DISTANCE, 1500).
+-define(DISTANCE, 1000).
 
 
 %% -----------------------------------------------------------------------------
@@ -254,7 +254,7 @@ next_state(S, _V, {call, _, refuel, [Value]}) ->
 
 %% Vanilla property based testing. This should not fail consistently.
 prop_distance() ->
-  ?FORALL(Cmds, more_commands(2, commands(?MODULE)),
+  ?FORALL(Cmds, commands(?MODULE),
           ?TRAPEXIT(
              begin
                start_link(),
@@ -269,7 +269,7 @@ prop_distance() ->
 %% provides failing command sequencies more consistently.
 prop_distance_targeted() ->
   ?FORALL_TARGETED(
-     Cmds, more_commands(2, targeted_commands(?MODULE)),
+     Cmds, targeted_commands(?MODULE),
      ?TRAPEXIT(
         begin
           start_link(),
@@ -286,7 +286,7 @@ prop_distance_targeted() ->
 prop_distance_targeted_init() ->
   State = initial_state(),
   ?FORALL_TARGETED(
-     Cmds, more_commands(2, targeted_commands(?MODULE, State)),
+     Cmds, targeted_commands(?MODULE, State),
      ?TRAPEXIT(
         begin
           start_link(),

--- a/examples_test/examples_tests.erl
+++ b/examples_test/examples_tests.erl
@@ -110,14 +110,14 @@ example_mastermind_props_test_() ->
 
 %% test the properties of `car_statem' example.
 example_car_statem_props_test_() ->
-  FailOpts = [{numtests,1000}, {constraint_tries,1000}, noshrink],
+  FailOpts = [{numtests,1000}, noshrink],
   [{timeout, 42, ?_passes(car_statem:prop_distance(), [500])},
-   {timeout, 600, ?_fails(car_statem:prop_distance_targeted(), FailOpts)},
-   {timeout, 600, ?_fails(car_statem:prop_distance_targeted_init(), FailOpts)}].
+   {timeout, 42, ?_fails(car_statem:prop_distance_targeted(), FailOpts)},
+   {timeout, 42, ?_fails(car_statem:prop_distance_targeted_init(), FailOpts)}].
 
 %% test the properties of `car_fsm' example.
 example_car_fsm_props_test_() ->
-  FailOpts = [{numtests,1000}, {constraint_tries,1000}, noshrink],
+  FailOpts = [{numtests,1000}, noshrink],
   [{timeout, 42, ?_passes(car_fsm:prop_distance(), [500])},
-   {timeout, 600, ?_fails(car_fsm:prop_distance_targeted(), FailOpts)},
-   {timeout, 600, ?_fails(car_fsm:prop_distance_targeted_init(), FailOpts)}].
+   {timeout, 42, ?_fails(car_fsm:prop_distance_targeted(), FailOpts)},
+   {timeout, 42, ?_fails(car_fsm:prop_distance_targeted_init(), FailOpts)}].

--- a/src/proper_fsm.erl
+++ b/src/proper_fsm.erl
@@ -176,8 +176,6 @@
 -export([targeted_commands/1, targeted_commands/2]).
 -export([command/1, precondition/2, next_state/3, postcondition/3]).
 -export([target_states/4]).
-%% Exported for PropEr internal usage.
--export([select_command/2]).
 
 -include("proper_internal.hrl").
 
@@ -202,9 +200,6 @@
 -type history()      :: [{fsm_state(),cmd_result()}].
 -type tmp_command()  :: {'init',state()}
 		      | {'set',symbolic_var(),symbolic_call()}.
--type weights()      :: #{{state_name(), state_name(), term()} =>
-                            pos_integer()}.
--type next_fun()     :: proper_statem:next_fun().
 
 -record(state, {name :: state_name(),
 		data :: state_data(),
@@ -272,9 +267,14 @@ commands(Mod, {Name,Data} = InitialState) ->
 
 -spec targeted_commands(mod_name()) -> proper_types:type().
 targeted_commands(Mod) ->
-  proper_types:add_prop(is_user_nf_stateful, true,
-                        ?USERNF(targeted_commands_gen(Mod),
-                                next_commands_gen(Mod))).
+  ?USERNF(commands(Mod), next_commands(Mod)).
+
+next_commands(Mod) ->
+  InitialState = initial_state(Mod),
+  StatemNext = proper_statem:next_commands(?MODULE, InitialState),
+  fun (Cmds, {Depth, Temp}) ->
+      ?LET([_ | NextCmds], StatemNext(Cmds, {Depth, Temp}), NextCmds)
+  end.
 
 %% @doc Similar to {@link targeted_commands/1}, but generated command
 %% sequences always start at a given state. In this case, the first
@@ -286,9 +286,15 @@ targeted_commands(Mod) ->
 
 -spec targeted_commands(mod_name(), fsm_state()) -> proper_types:type().
 targeted_commands(Mod, InitialState) ->
-  proper_types:add_prop(is_user_nf_stateful, true,
-                        ?USERNF(targeted_commands_gen(Mod, InitialState),
-                                next_commands_gen(Mod, InitialState))).
+  ?USERNF(commands(Mod, InitialState), next_commands(Mod, InitialState)).
+
+next_commands(Mod, {Name, Data} = InitialState) ->
+  State = #state{name = Name, data = Data, mod = Mod},
+  StatemNext = proper_statem:next_commands(?MODULE, State),
+  fun (Cmds, {Depth, Temp}) ->
+      ?LET([_ | NextCmds], StatemNext(Cmds, {Depth, Temp}),
+           [{init, InitialState} | NextCmds])
+  end.
 
 %% @doc Evaluates a given symbolic command sequence `Cmds' according to the
 %% finite state machine specified in `Mod'. The result is a triple of the
@@ -369,108 +375,6 @@ next_state(S = #state{name = From, data = Data, mod = Mod} , Var, Call) ->
 postcondition(#state{name = From, data = Data, mod = Mod}, Call, Res) ->
     To = cook_history(From, transition_target(Mod, From, Data, Call)),
     Mod:postcondition(From, To, Data, Call, Res).
-
-
-%% -----------------------------------------------------------------------------
-%% Targeted command generation
-%% -----------------------------------------------------------------------------
-
-
--spec targeted_commands_gen(mod_name()) -> proper_types:type().
-targeted_commands_gen(Mod) ->
-  State = initial_state(Mod),
-  ?LET([_ | Cmds], proper_statem:commands(?MODULE, State),
-       {finalize_weights(State, Cmds, maps:new()), Cmds}).
-
--spec targeted_commands_gen(mod_name(), fsm_state()) -> proper_types:type().
-targeted_commands_gen(Mod, {Name, Data} = InitialState) ->
-  State = #state{name = Name, data = Data, mod = Mod},
-  ?LET([_ | Cmds], proper_statem:commands(?MODULE, State),
-       {finalize_weights(State, Cmds, maps:new()),
-        [{init, InitialState} | Cmds]}).
-
--spec next_commands_gen(mod_name()) -> next_fun().
-next_commands_gen(Mod) ->
-  fun ({Weights, _Cmds}, {_D, T}) ->
-      State = initial_state(Mod),
-      NewWeights = proper_statem:next_weights(Weights, T),
-      CmdsGen = ?LET([_ | Cmds],
-                     proper_statem:next_gen(?MODULE, NewWeights, State),
-                     Cmds),
-      ?SHRINK(
-         ?LET(Cmds, ?LAZY(CmdsGen),
-              {finalize_weights(State, Cmds, NewWeights), Cmds}),
-         [CmdsGen])
-  end.
-
--spec next_commands_gen(mod_name(), fsm_state()) -> next_fun().
-next_commands_gen(Mod, {Name, Data} = InitialState) ->
-  fun ({Weights, _Cmds}, {_D, T}) ->
-      State = #state{name = Name, data = Data, mod = Mod},
-      NewWeights = proper_statem:next_weights(Weights, T),
-      CmdsGen = ?LET([_ | Cmds],
-                     proper_statem:next_gen(?MODULE, NewWeights, State),
-                     [{init, InitialState} | Cmds]),
-      ?SHRINK(
-         ?LET(Cmds, ?LAZY(CmdsGen),
-              {finalize_weights(State, Cmds, NewWeights), Cmds}),
-         [CmdsGen])
-  end.
-
-%% Commands are selected according to the weights found in the
-%% map provided, or from a `weight/3' callback.
-
-%% @private
--spec select_command(state(), weights()) -> proper_types:type().
-select_command(State, Weights) ->
-  #state{name = From, data = Data, mod = Mod} = State,
-  SelectAux =
-    fun ({To, {call, _Mod, Call, _Args} = SymbCall}) ->
-        RealTo = cook_history(From, To),
-        Key = {From, RealTo, Call},
-        Weight = case maps:is_key(Key, Weights) of
-                   true -> maps:get(Key, Weights);
-                   false ->
-                     case is_exported(Mod, {weight, 3}) of
-                       true -> Mod:weight(From, RealTo, SymbCall);
-                       false -> 1
-                     end
-                 end,
-        {Weight, SymbCall}
-    end,
-  Transitions = get_transitions(Mod, From, Data),
-  WeightedCmds = lists:map(SelectAux, Transitions),
-  proper_types:frequency(WeightedCmds).
-
-%% Track all the state transitions and add them to the weights map.
-
--spec finalize_weights(state(), command_list(), weights()) -> weights().
-finalize_weights(_S, [], Weights) -> Weights;
-finalize_weights(InitialState, Cmds, Weights) ->
-  FinWeightsAux =
-    fun ({init, _InitialState}, Acc) -> Acc;
-        ({set, Var, SymbCall}, {State, Ws}) ->
-        #state{name = From, data = Data, mod = Mod} = State,
-        FoldAux =
-          fun ({To, {call, _M, Call, _A} = SC}, Acc) ->
-              RealTo = cook_history(From, To),
-              Key = {From, RealTo, Call},
-              W = case is_exported(Mod, {weight, 3}) of
-                    true -> Mod:weight(From, RealTo, SC);
-                    false -> 1
-                  end,
-              case maps:is_key(Key, Acc) of
-                true -> Acc;
-                false -> maps:put(Key, W, Acc)
-              end
-          end,
-        NextState = next_state(State, Var, SymbCall),
-        Transitions = get_transitions(Mod, From, Data),
-        NewWs = lists:foldl(FoldAux, Ws, Transitions),
-        {NextState, NewWs}
-    end,
-  {_S, NewWeights} = lists:foldl(FinWeightsAux, {InitialState, Weights}, Cmds),
-  NewWeights.
 
 
 %% -----------------------------------------------------------------------------

--- a/src/proper_gen_next.erl
+++ b/src/proper_gen_next.erl
@@ -184,7 +184,8 @@ restrict_generation(_, _, T, 0, Type, none) ->
 restrict_generation(_, _, _, 0, _, {ok, WeakInstance}) -> WeakInstance;
 restrict_generation(Gen, B, T, TriesLeft, Type, WeakInstance) ->
   Instance = Gen(B, T),
-  case proper_types:satisfies_all(Instance, Type) of
+  CleanInstance = proper_gen:clean_instance(Instance),
+  case proper_types:satisfies_all(CleanInstance, Type) of
     {true, true} ->
       %% strong
       Instance;

--- a/src/proper_types.erl
+++ b/src/proper_types.erl
@@ -241,7 +241,7 @@
 			| 'get_length' | 'split' | 'join' | 'get_indices'
 			| 'remove' | 'retrieve' | 'update' | 'constraints'
 			| 'parameters' | 'env' | 'subenv'
-			| 'user_nf' | 'is_user_nf' | 'is_user_nf_stateful' | 'matcher'.
+			| 'user_nf' | 'is_user_nf' | 'matcher'.
 
 -type type_prop_value() :: term().
 -type type_prop() ::
@@ -291,8 +291,7 @@
     | {'env', term()}
     | {'subenv', term()}
     | {'user_nf', proper_gen_next:nf()}
-    | {'is_user_nf', boolean()}
-    | {'is_user_nf_stateful', boolean()}.
+    | {'is_user_nf', boolean()}.
 
 
 %%------------------------------------------------------------------------------

--- a/test/proper_tests.erl
+++ b/test/proper_tests.erl
@@ -997,7 +997,9 @@ true_stateful_test_() ->
      {timeout, 20, ?_passes(ets_statem_test:prop_parallel_ets())},
      {timeout, 20, ?_passes(pdict_fsm:prop_pdict())},
      {timeout, 20, ?_passes(symb_statem:prop_parallel_simple())},
-     {timeout, 20, ?_passes(symb_statem_maps:prop_parallel_simple())}].
+     {timeout, 20, ?_passes(symb_statem_maps:prop_parallel_simple())},
+     {timeout, 42, ?_passes(targeted_statem:prop_random(), [{numtests,500}])},
+     {timeout, 42, ?_passes(targeted_fsm:prop_random(), [{numtests,500}])}].
 
 false_props_test_() ->
     [?_failsWith([[_Same,_Same]],
@@ -1088,6 +1090,13 @@ false_props_test_() ->
      ?_failsWith([500], targeted_shrinking_test:prop_int_shrink_inner()),
      {timeout, 20, ?_fails(ets_counter:prop_ets_counter())},
      ?_fails(post_false:prop_simple())].
+
+false_stateful_test_() ->
+  Opts = [{numtests,1000}],
+  [{timeout, 42, ?_fails(targeted_statem:prop_targeted(), Opts)},
+   {timeout, 42, ?_fails(targeted_statem:prop_targeted_init(), Opts)},
+   {timeout, 42, ?_fails(targeted_fsm:prop_targeted(), Opts)},
+   {timeout, 42, ?_fails(targeted_fsm:prop_targeted_init(), Opts)}].
 
 exception_props_test_() ->
      [?_fails(error_statem:prop_simple())].

--- a/test/targeted_fsm.erl
+++ b/test/targeted_fsm.erl
@@ -1,0 +1,130 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
+%%% Copyright 2020-     Manolis Papadakis <manopapad@gmail.com>,
+%%%                     Eirini Arvaniti <eirinibob@gmail.com>
+%%%                 and Kostis Sagonas <kostis@cs.ntua.gr>
+%%%
+%%% This file is part of PropEr.
+%%%
+%%% PropEr is free software: you can redistribute it and/or modify
+%%% it under the terms of the GNU General Public License as published by
+%%% the Free Software Foundation, either version 3 of the License, or
+%%% (at your option) any later version.
+%%%
+%%% PropEr is distributed in the hope that it will be useful,
+%%% but WITHOUT ANY WARRANTY; without even the implied warranty of
+%%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%%% GNU General Public License for more details.
+%%%
+%%% You should have received a copy of the GNU General Public License
+%%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
+
+%%% @copyright 2020 Spiros Dontas and Kostis Sagonas
+%%% @version {@version}
+%%% @author Spiros Dontas
+
+%% This file is only present to make sure that the proper_fsm TPBT works
+%% properly, as well as increase the coverage.
+
+-module(targeted_fsm).
+-behaviour(proper_fsm).
+
+-export([initial_state/0, initial_state_data/0, precondition/4,
+         next_state_data/5, postcondition/5, empty_ets/1, non_empty_ets/1]).
+
+-include_lib("proper/include/proper.hrl").
+
+-define(MAX_SIZE, 15).
+-define(TAB, targeted_statem_table).
+
+
+%% -----------------------------------------------------------------------------
+%% proper_fsm callbacks
+%% -----------------------------------------------------------------------------
+
+
+unique_key(S) ->
+  ?SUCHTHAT(I, integer(1, 100),
+            length(lists:filter(fun ({K, _}) -> K =:= I end, S)) =:= 0).
+key(S) ->
+  oneof([oneof([Key || {Key, _} <- S]),
+         unique_key(S)]).
+value() ->
+  integer().
+
+initial_state() -> empty_ets.
+
+initial_state_data() -> [].
+
+precondition(_, non_empty_ets, _S, {call, ets, insert, _}) -> true;
+precondition(_, non_empty_ets, _S, {call, ets, lookup, _}) -> true;
+precondition(_, empty_ets, _S, {call, ets, delete_all_objects, _}) -> true.
+
+next_state_data(_, _, S, _V, {call, ets, insert, [_, {Key, Value}]}) ->
+  case proplists:is_defined(Key, S) of
+    true -> lists:keyreplace(Key, 1, S, {Key, Value});
+    false -> [{Key, Value} | S]
+  end;
+next_state_data(_, _, S, _V, {call, ets, lookup, _}) -> S;
+next_state_data(_, _, _S, _V, {call, ets, delete_all_objects, [_]}) -> [].
+
+postcondition(_, _, S, {call, ets, insert, [_, {Key, _Value}]}, _R) ->
+  case proplists:is_defined(Key, S) of
+    true -> true;
+    false -> length(S) + 1 < ?MAX_SIZE
+  end;
+postcondition(_, _, S, {call, ets, lookup, [_, Key]}, R) ->
+  proplists:lookup_all(Key, S) =:= R;
+postcondition(_, _, _S, _C, _R) -> true.
+
+empty_ets(_S) ->
+  [{non_empty_ets, {call, ets, insert, [?TAB, {unique_key([]), value()}]}}].
+
+non_empty_ets(S) ->
+  [{empty_ets, {call, ets, delete_all_objects, [?TAB]}},
+   {history, {call, ets, insert, [?TAB, {key(S), integer()}]}},
+   {history, {call, ets, lookup, [?TAB, key(S)]}}].
+
+
+%% -----------------------------------------------------------------------------
+%% Properties
+%% -----------------------------------------------------------------------------
+
+
+prop_random() ->
+  ?FORALL(Cmds, proper_fsm:commands(?MODULE),
+          begin
+            catch ets:delete(?TAB),
+            ?TAB = ets:new(?TAB, [set, public, named_table]),
+            {H, _S, Res} = proper_fsm:run_commands(?MODULE, Cmds),
+            ets:delete(?TAB),
+            aggregate(zip(proper_fsm:state_names(H), command_names(Cmds)),
+                      Res =:= ok)
+          end).
+
+prop_targeted() ->
+  ?FORALL_TARGETED(
+     Cmds, proper_fsm:targeted_commands(?MODULE),
+     begin
+       catch ets:delete(?TAB),
+       ?TAB = ets:new(?TAB, [set, public, named_table]),
+       {H, {_, S}, Res} = proper_fsm:run_commands(?MODULE, Cmds),
+       ets:delete(?TAB),
+       ?MAXIMIZE(length(S)),
+       aggregate(zip(proper_fsm:state_names(H), command_names(Cmds)),
+                 Res =:= ok)
+     end).
+
+prop_targeted_init() ->
+  ?FORALL_TARGETED(
+     Cmds, proper_fsm:targeted_commands(?MODULE, {empty_ets, []}),
+     begin
+       catch ets:delete(?TAB),
+       ?TAB = ets:new(?TAB, [set, public, named_table]),
+       {H, {_, S}, Res} = proper_fsm:run_commands(?MODULE, Cmds),
+       ets:delete(?TAB),
+       ?MAXIMIZE(length(S)),
+       aggregate(zip(proper_fsm:state_names(H), command_names(Cmds)),
+                 Res =:= ok)
+     end).

--- a/test/targeted_fsm.erl
+++ b/test/targeted_fsm.erl
@@ -78,8 +78,8 @@ postcondition(_, _, S, {call, ets, lookup, [_, Key]}, R) ->
   proplists:lookup_all(Key, S) =:= R;
 postcondition(_, _, _S, _C, _R) -> true.
 
-empty_ets(_S) ->
-  [{non_empty_ets, {call, ets, insert, [?TAB, {unique_key([]), value()}]}}].
+empty_ets(S) ->
+  [{non_empty_ets, {call, ets, insert, [?TAB, {unique_key(S), value()}]}}].
 
 non_empty_ets(S) ->
   [{empty_ets, {call, ets, delete_all_objects, [?TAB]}},

--- a/test/targeted_statem.erl
+++ b/test/targeted_statem.erl
@@ -1,0 +1,120 @@
+%%% -*- coding: utf-8 -*-
+%%% -*- erlang-indent-level: 2 -*-
+%%% -------------------------------------------------------------------
+%%% Copyright 2020-     Manolis Papadakis <manopapad@gmail.com>,
+%%%                     Eirini Arvaniti <eirinibob@gmail.com>
+%%%                 and Kostis Sagonas <kostis@cs.ntua.gr>
+%%%
+%%% This file is part of PropEr.
+%%%
+%%% PropEr is free software: you can redistribute it and/or modify
+%%% it under the terms of the GNU General Public License as published by
+%%% the Free Software Foundation, either version 3 of the License, or
+%%% (at your option) any later version.
+%%%
+%%% PropEr is distributed in the hope that it will be useful,
+%%% but WITHOUT ANY WARRANTY; without even the implied warranty of
+%%% MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+%%% GNU General Public License for more details.
+%%%
+%%% You should have received a copy of the GNU General Public License
+%%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
+
+%%% @copyright 2020 Spiros Dontas and Kostis Sagonas
+%%% @version {@version}
+%%% @author Spiros Dontas
+
+%% This file is only present to make sure that the proper_statem TPBT works
+%% properly, as well as increase the coverage.
+
+-module(targeted_statem).
+-behaviour(proper_statem).
+
+-export([initial_state/0, command/1, precondition/2, next_state/3,
+         postcondition/3]).
+
+-include_lib("proper/include/proper.hrl").
+
+-define(MAX_SIZE, 15).
+-define(TAB, targeted_statem_table).
+
+
+%% -----------------------------------------------------------------------------
+%% proper_statem callbacks
+%% -----------------------------------------------------------------------------
+
+
+unique_key(S) ->
+  ?SUCHTHAT(I, integer(1, 100),
+            length(lists:filter(fun ({K, _}) -> K =:= I end, S)) =:= 0).
+key(S) ->
+  oneof([oneof([Key || {Key, _} <- S]),
+         unique_key(S)]).
+value() ->
+  integer().
+
+initial_state() -> [].
+
+command([]) ->
+  {call, ets, insert, [?TAB, {unique_key([]), value()}]};
+command(S) ->
+  oneof([{call, ets, insert, [?TAB, {key(S), value()}]},
+         {call, ets, lookup, [?TAB, key(S)]},
+         {call, ets, delete_all_objects, [?TAB]}]).
+
+precondition(_S, _C) -> true.
+
+next_state(S, _V, {call, ets, insert, [_, {Key, Value}]}) ->
+  case proplists:is_defined(Key, S) of
+    true -> lists:keyreplace(Key, 1, S, {Key, Value});
+    false -> [{Key, Value} | S]
+  end;
+next_state(S, _V, {call, ets, lookup, _}) -> S;
+next_state(_S, _V, {call, ets, delete_all_objects, [_]}) -> [].
+
+postcondition(S, {call, ets, insert, [_, {Key, _Value}]}, _R) ->
+  case proplists:is_defined(Key, S) of
+    true -> true;
+    false -> length(S) + 1 < ?MAX_SIZE
+  end;
+postcondition(S, {call, ets, lookup, [_, Key]}, R) ->
+  proplists:lookup_all(Key, S) =:= R;
+postcondition(_S, _C, _R) -> true.
+
+
+%% -----------------------------------------------------------------------------
+%% Properties
+%% -----------------------------------------------------------------------------
+
+
+prop_random() ->
+  ?FORALL(Cmds, commands(?MODULE),
+          begin
+            catch ets:delete(?TAB),
+            ?TAB = ets:new(?TAB, [set, public, named_table]),
+            {_H, _S, Res} = run_commands(?MODULE, Cmds),
+            ets:delete(?TAB),
+            aggregate(command_names(Cmds), Res =:= ok)
+          end).
+
+prop_targeted() ->
+  ?FORALL_TARGETED(Cmds, targeted_commands(?MODULE),
+                   begin
+                     catch ets:delete(?TAB),
+                     ?TAB = ets:new(?TAB, [set, public, named_table]),
+                     {_H, S, Res} = run_commands(?MODULE, Cmds),
+                     ets:delete(?TAB),
+                     ?MAXIMIZE(length(S)),
+                     aggregate(command_names(Cmds), Res =:= ok)
+                   end).
+
+prop_targeted_init() ->
+  ?FORALL_TARGETED(Cmds, targeted_commands(?MODULE, []),
+                   begin
+                     catch ets:delete(?TAB),
+                     ?TAB = ets:new(?TAB, [set, public, named_table]),
+                     {_H, S, Res} = run_commands(?MODULE, Cmds),
+                     ets:delete(?TAB),
+                     ?MAXIMIZE(length(S)),
+                     aggregate(command_names(Cmds), Res =:= ok)
+                   end).


### PR DESCRIPTION
This PR updates the implementation of the stateful targeted
property based testing, in order to make it better in two ways:

- Make the codebase a lot smaller.
- Make the search much more effective.