### PR TITLE
fix float format in plain_stats_printer/3

### DIFF
--- a/src/proper.erl
+++ b/src/proper.erl
@@ -2145,7 +2145,12 @@ with_title(Title) ->
 plain_stats_printer(SortedSample, Print, Title) ->
     print_title(Title, Print),
     Total = length(SortedSample),
-    PrFun = fun ({Cmd,Fr}) -> Print("~5.2f\% ~w~n", [100 * Fr / Total,Cmd]) end,
+    PrFun = fun ({Cmd,Fr}) ->
+        case Fr =:= Total of
+          true  -> Print("100.0\% ~w~n", [Cmd]);
+          false -> Print("~5.2f\% ~w~n", [100 * Fr / Total,Cmd])
+        end
+    end,
     lists:foreach(PrFun, process_sorted_sample(SortedSample)).
 
 -spec print_title(title(), output_fun()) -> 'ok'.


### PR DESCRIPTION
Hello,
during my work on updating the [elixir library](https://github.com/alfert/propcheck/pull/179) I found an issue in proper:

Seems like for success case (100.00%)  plain_stats_printer/3 will return asterisks instead of a formatted number:

Check:
```erlang
io:fwrite("====== 5.2 can fail =====~n"),
io:fwrite("~5.2f ~n", [1000 * 30 / 70]),
io:fwrite("~5.2f ~n", [100 * 30 / 30]),
io:fwrite("~5.2f ~n", [100 * 18 / 30]),
io:fwrite("~5.2f ~n", [100 * 1 / 30]).
```
```sh
====== 5.2 can fail =====
*****
*****
60.00
 3.33
```

As a fix I extended formatting to 6 digits but 5.1 also will work:
```erlang
io:fwrite("===== 6.2 ok =====~n"),
io:fwrite("~6.2f ~n", [1000 * 30 / 70]),
io:fwrite("~6.2f ~n", [100 * 30 / 30]),
io:fwrite("~6.2f ~n", [100 * 18 / 30]),
io:fwrite("~6.2f ~n", [100 * 1 / 30]),
io:fwrite("===== 5.1 ok =====~n"),
io:fwrite("~5.1f ~n", [1000 * 30 / 70]),
io:fwrite("~5.1f ~n", [100 * 30 / 30]),
io:fwrite("~5.1f ~n", [100 * 18 / 30]),
io:fwrite("~5.1f ~n", [100 * 1 / 30]),
io:fwrite("==================~n").
``` 

```sh
===== 6.2 ok =====
428.57
100.00
 60.00
  3.33
===== 5.1 ok =====
428.6
100.0
 60.0
  3.3
==================
```

Also, it's quite a while now when `proper` lib was released last time.
So I would like to ask if there are any plans to push a new version?