### PR TITLE
Increase coverage of proper_erlang_abstract_code

### DIFF
--- a/src/proper_erlang_abstract_code.erl
+++ b/src/proper_erlang_abstract_code.erl
@@ -51,7 +51,7 @@
 %%%
 %%% ```
 %%% test() ->
-%%%     ?FORALL(Abstr, proper_abstr:module(),
+%%%     ?FORALL(Abstr, proper_erlang_abstract_code:module(),
 %%%             ?WHENFAIL(
 %%%                begin
 %%%                    io:format("~ts\n", [[erl_pp:form(F) || F <- Abstr]]),
@@ -66,7 +66,6 @@
 %%%     compile:noenv_forms(Abstr, Opts).
 %%% '''
 -module(proper_erlang_abstract_code).
-
 
 -export([module/0, module/1, guard/0, guard/1, expr/0, expr/1]).
 
@@ -1511,7 +1510,7 @@ bytes(S) ->
     {'bin', anno(), binelement_seq_term(S, bytes)}.
 
 bits(#gen_state{result_type = term} = S, compound) ->
-     {'bin', anno(), binelement_seq_term(S, bits)};
+    {'bin', anno(), binelement_seq_term(S, bits)};
 bits(S, compound=Where) ->
     LiteralW = get_weight(literal_bits, S),
     WildBitsW = wild_bits_weight(S),
@@ -2386,7 +2385,7 @@ default_limits() ->
       record_fields => ?MAX_RECORD_FIELDS,
       tsl => ?MAX_TYPE_SPECIFIER,
       union_types => ?MAX_UNION_TYPES
-      }.
+     }.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 

--- a/test/erlang_abstract_code_test.erl
+++ b/test/erlang_abstract_code_test.erl
@@ -36,7 +36,7 @@
 %%% @doc This module is a smoke test of the Erlang abstract code generator.
 -module(erlang_abstract_code_test).
 
--export([bits/0, expr/0, guard/0, term/0, program/0]).
+-export([bits/0, expr/0, guard/0, term/0, module/0]).
 
 -include_lib("proper/include/proper.hrl").
 
@@ -59,20 +59,16 @@ expr(Opts) ->
 guard() ->
     G = proper_erlang_abstract_code:guard(),
     ?FORALL(X, G, check_pp(erl_pp:guard((X)))).
-    
-program() ->
-    P = proper_erlang_abstract_code:module(),
-    ?FORALL(X, P, lists:all(fun(F) -> check_pp(erl_pp:form(F)) end, X)).
 
 term() ->
     T = proper_erlang_abstract_code:term(),
     ?FORALL(X, T, check_pp(erl_pp:expr(X))).
 
-check_pp(S) ->
-    case string:find(S, "INVALID-FORM") of
-        nomatch ->
-            true;
-        _ ->
-            false
-    end.
+module() ->
+    %% enable some elements which are off by default
+    Opts = [{weight, {D, 1}} || D <- [type_decl, function_spec]],
+    P = proper_erlang_abstract_code:module(Opts),
+    ?FORALL(X, P, lists:all(fun(F) -> check_pp(erl_pp:form(F)) end, X)).
 
+check_pp(S) ->
+    string:find(S, "INVALID-FORM") =:= nomatch.

--- a/test/erlang_abstract_code_test.erl
+++ b/test/erlang_abstract_code_test.erl
@@ -66,7 +66,7 @@ term() ->
 
 module() ->
     %% enable some elements which are off by default
-    Opts = [{weight, {D, 1}} || D <- [type_decl, function_spec]],
+    Opts = [{weight, {D, 1}} || D <- [type_decl, function_spec, termcall]],
     P = proper_erlang_abstract_code:module(Opts),
     ?FORALL(X, P, lists:all(fun(F) -> check_pp(erl_pp:form(F)) end, X)).
 

--- a/test/proper_tests.erl
+++ b/test/proper_tests.erl
@@ -1430,7 +1430,7 @@ max_size_test_aux(Size) ->
 erlang_abstract_code_test_() ->
     M = erlang_abstract_code_test,
     Props = [bits, expr, guard, term, module],
-    Opts = [{numtests, 500}, noshrink],
+    Opts = [{numtests, 200}, noshrink],
     [?_assertEqual(true, proper:quickcheck(M:Prop(), Opts)) || Prop <- Props].
 
 %%------------------------------------------------------------------------------

--- a/test/proper_tests.erl
+++ b/test/proper_tests.erl
@@ -1427,12 +1427,11 @@ max_size_test_aux(Size) ->
 %% Erlang abstract code tests
 %%------------------------------------------------------------------------------
 
-erlang_abstract_code_test() ->
-    Opts = [{numtests, 100}, noshrink],
-    Props = [bits, expr, term, guard, program],
-    [?assertEqual(true, proper:quickcheck(erlang_abstract_code_test:Prop(),
-                                          Opts)) ||
-        Prop <- Props].
+erlang_abstract_code_test_() ->
+    M = erlang_abstract_code_test,
+    Props = [bits, expr, guard, term, module],
+    Opts = [{numtests, 500}, noshrink],
+    [?_assertEqual(true, proper:quickcheck(M:Prop(), Opts)) || Prop <- Props].
 
 %%------------------------------------------------------------------------------
 %% Helper predicates


### PR DESCRIPTION
The test coverage of the new module was pretty good (~88%) but it could get better by selecting non-zero weights for some language constructs (e.g. type declarations, specs, etc.) which were zero by default.  This increased the coverage to ~94%.

While at it, did some cleanups and fixed a small glitch in the documentation concerning the name of this module.