### PR TITLE
Merge targeted with random commands generator

### DIFF
--- a/examples/car_fsm.erl
+++ b/examples/car_fsm.erl
@@ -342,7 +342,7 @@ prop_distance() ->
 %% provides failing command sequencies more consistently.
 prop_distance_targeted() ->
   ?FORALL_TARGETED(
-     Cmds, proper_fsm:targeted_commands(?MODULE),
+     Cmds, proper_fsm:commands(?MODULE),
      ?TRAPEXIT(
         begin
           start_link(),
@@ -360,7 +360,7 @@ prop_distance_targeted() ->
 prop_distance_targeted_init() ->
   State = {initial_state(), initial_state_data()},
   ?FORALL_TARGETED(
-     Cmds, proper_fsm:targeted_commands(?MODULE, State),
+     Cmds, proper_fsm:commands(?MODULE, State),
      ?TRAPEXIT(
         begin
           start_link(),

--- a/examples/car_statem.erl
+++ b/examples/car_statem.erl
@@ -269,7 +269,7 @@ prop_distance() ->
 %% provides failing command sequencies more consistently.
 prop_distance_targeted() ->
   ?FORALL_TARGETED(
-     Cmds, targeted_commands(?MODULE),
+     Cmds, commands(?MODULE),
      ?TRAPEXIT(
         begin
           start_link(),
@@ -286,7 +286,7 @@ prop_distance_targeted() ->
 prop_distance_targeted_init() ->
   State = initial_state(),
   ?FORALL_TARGETED(
-     Cmds, targeted_commands(?MODULE, State),
+     Cmds, commands(?MODULE, State),
      ?TRAPEXIT(
         begin
           start_link(),

--- a/include/proper.hrl
+++ b/include/proper.hrl
@@ -94,7 +94,6 @@
 
 -import(proper_statem, [commands/1, commands/2, parallel_commands/1,
 			parallel_commands/2, more_commands/2]).
--import(proper_statem, [targeted_commands/1, targeted_commands/2]).
 -import(proper_statem, [run_commands/2, run_commands/3,  state_after/2,
 			command_names/1, zip/2, run_parallel_commands/2,
 			run_parallel_commands/3]).

--- a/test/proper_tests.erl
+++ b/test/proper_tests.erl
@@ -1112,7 +1112,7 @@ error_props_test_() ->
 		   ?FORALL(X, integer(), ?IMPLIES(X > 5, X < 6))),
      ?_assertCheck({error,too_many_instances}, [1,ab],
 		   ?FORALL(X, pos_integer(), X < 0)),
-     ?_errorsOut({cant_generate,[{proper_statem,commands,4}]},
+     ?_errorsOut({cant_generate,[{proper_statem,commands_gen,4}]},
 		 prec_false:prop_simple()),
      ?_errorsOut({cant_generate,[{nogen_statem,impossible_arg,0}]},
 		 nogen_statem:prop_simple()),

--- a/test/targeted_fsm.erl
+++ b/test/targeted_fsm.erl
@@ -101,7 +101,7 @@ prop_random() ->
 
 prop_targeted() ->
   ?FORALL_TARGETED(
-     Cmds, proper_fsm:targeted_commands(?MODULE),
+     Cmds, proper_fsm:commands(?MODULE),
      begin
        catch ets:delete(?TAB),
        ?TAB = ets:new(?TAB, [set, public, named_table]),
@@ -114,7 +114,7 @@ prop_targeted() ->
 
 prop_targeted_init() ->
   ?FORALL_TARGETED(
-     Cmds, proper_fsm:targeted_commands(?MODULE, {empty_ets, []}),
+     Cmds, proper_fsm:commands(?MODULE, {empty_ets, []}),
      begin
        catch ets:delete(?TAB),
        ?TAB = ets:new(?TAB, [set, public, named_table]),

--- a/test/targeted_statem.erl
+++ b/test/targeted_statem.erl
@@ -94,7 +94,7 @@ prop_random() ->
           end).
 
 prop_targeted() ->
-  ?FORALL_TARGETED(Cmds, targeted_commands(?MODULE),
+  ?FORALL_TARGETED(Cmds, commands(?MODULE),
                    begin
                      catch ets:delete(?TAB),
                      ?TAB = ets:new(?TAB, [set, public, named_table]),
@@ -105,7 +105,7 @@ prop_targeted() ->
                    end).
 
 prop_targeted_init() ->
-  ?FORALL_TARGETED(Cmds, targeted_commands(?MODULE, []),
+  ?FORALL_TARGETED(Cmds, commands(?MODULE, []),
                    begin
                      catch ets:delete(?TAB),
                      ?TAB = ets:new(?TAB, [set, public, named_table]),


### PR DESCRIPTION
This PR removes the need of the separate `targeted_commands` generators when using Targeted Stateful PBT. Instead, users can now use the same `commands` generator in order to perform both random and targeted testing for stateful systems.