### PR TITLE
Suppress warnings on unused types

### DIFF
--- a/include/proper.hrl
+++ b/include/proper.hrl
@@ -1,8 +1,7 @@
-%%% -*- coding: utf-8 -*-
-%%% -*- erlang-indent-level: 2 -*-
+%%% -*- coding: utf-8; erlang-indent-level: 2 -*-
 %%% -------------------------------------------------------------------
-%%% Copyright 2010-2017 Manolis Papadakis <manopapad@gmail.com>,
-%%%                     Eirini Arvaniti <eirinibob@gmail.com>
+%%% Copyright 2010-2021 Manolis Papadakis <manopapad@gmail.com>,
+%%%                     Eirini Arvaniti <eirinibob@gmail.com>,
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>
 %%%
 %%% This file is part of PropEr.
@@ -20,13 +19,14 @@
 %%% You should have received a copy of the GNU General Public License
 %%% along with PropEr.  If not, see <http://www.gnu.org/licenses/>.
 
-%%% @copyright 2010-2017 Manolis Papadakis, Eirini Arvaniti and Kostis Sagonas
+%%% @copyright 2010-2021 Manolis Papadakis, Eirini Arvaniti, and Kostis Sagonas
 %%% @version {@version}
 %%% @author Manolis Papadakis
 %%% @doc User header file: This file should be included in each file containing
 %%%      user type declarations and/or properties to be tested.
 
 -compile(debug_info).
+-compile(nowarn_unused_type).
 
 -include_lib("proper/include/proper_common.hrl").
 


### PR DESCRIPTION
PropEr has the ability to turn type declarations into generators, and
thus allows types to appear in places where function calls would be
expected.  Alas, the Erlang compiler is unaware of this, and warns that
types are unused, as in the module below.  A simple fix, at least for
the time being, is to explicitly enable the compiler option that shuts
off compiler warnings about unused types.  Of course, a better option
would be for the Erlang compiler to be PropEr-aware...

-module(tt).
-include_lib("proper/include/proper.hrl").

-type t() :: 1..42.

prop_foo() ->
  ?FORALL(X, t(), X > 0).