### PR TITLE
mark covertool as project_plugin

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -63,7 +63,7 @@
 {dialyzer, [{warnings, [unmatched_returns, unknown]},
             {plt_extra_apps, [erts, kernel, stdlib, compiler, crypto, syntax_tools, eunit]}]}.
 
-{plugins, [covertool]}.
+{project_plugins, [covertool]}.
 {cover_export_enabled, true}.
 {covertool, [{coverdata_files, ["eunit.coverdata"]}]}.
 


### PR DESCRIPTION
coverall should not be a transitive dependency for proper, and only
be respected when developing proper itself (specifically for CI runs)

see http://rebar3.org/docs/configuration/plugins/#project-plugins-and-overriding-commands