### PR TITLE
Use covertool as a project_plugin, rather than plugin

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -63,7 +63,7 @@
 {dialyzer, [{warnings, [unmatched_returns, unknown]},
             {plt_extra_apps, [erts, kernel, stdlib, compiler, crypto, syntax_tools, eunit]}]}.
 
-{plugins, [covertool]}.
+{project_plugins, [covertool]}.
 {cover_export_enabled, true}.
 {covertool, [{coverdata_files, ["eunit.coverdata"]}]}.
 


### PR DESCRIPTION
This was resulting in `covertool` being pulled-in as a dependency needlessly in downstream projects in some situations.

Using it as a `project_plugin` is advised by `covertool` [itself](https://github.com/covertool/covertool#rebar3).

More on plugins vs project plugins: https://rebar3.readme.io/docs/using-available-plugins