### PR TITLE
Address deprecation warnings in OTP25

### DIFF
--- a/include/proper_internal.hrl
+++ b/include/proper_internal.hrl
@@ -37,10 +37,6 @@
         {ok, Pid, Node} ->
             register(Node, Pid),
             _ = update_worker_node_ref({Node, {already_running, false}}),
-            Node;
-        {ok, Pid} ->
-            Node = list_to_atom(lists:concat([Name, "@", net_adm:localhost()])),
-            register(Node, Pid),
             Node;).
 -define(STOP_PEER_NODE(Name),
         peer:stop(Name)).

--- a/include/proper_internal.hrl
+++ b/include/proper_internal.hrl
@@ -27,6 +27,28 @@
 
 -include("proper_common.hrl").
 
+%%------------------------------------------------------------------------------
+%% Peer node module definition
+%%------------------------------------------------------------------------------
+
+%% OTP25 introduced `peer` to replace the `slave' module.
+%% It has a different API, so for now we have to live with macros to
+%% conditionally compile the proper code to handle the node setup.
+%% This whole setup can be removed once PropEr requires at the very least OTP25 to run.
+-if (?OTP_RELEASE >= 25).
+-define(START_PEER_NODE(Name),
+        peer:start(#{name => Name})).
+-define(STOP_PEER_NODE(Name),
+        peer:stop(Name)).
+-else.
+-define(START_PEER_NODE(Name),
+        begin
+            HostName = list_to_atom(net_adm:localhost()),
+            slave:start_link(HostName, Name)
+        end).
+-define(STOP_PEER_NODE(Name),
+        slave:stop(Node)).
+-endif.
 
 %%------------------------------------------------------------------------------
 %% Random generator selection

--- a/include/proper_internal.hrl
+++ b/include/proper_internal.hrl
@@ -31,21 +31,18 @@
 %% Peer node module definition
 %%------------------------------------------------------------------------------
 
-%% OTP25 introduced `peer` to replace the `slave' module.
-%% It has a different API, so for now we have to live with macros to
-%% conditionally compile the proper code to handle the node setup.
-%% This whole setup can be removed once PropEr requires at the very least OTP25 to run.
 -if (?OTP_RELEASE >= 25).
--define(START_PEER_NODE(Name),
-        peer:start(#{name => Name})).
+-define(CASE_START_PEER_NODE(Name),
+    case peer:start(#{name => Name}) of
+        {ok, Pid, Node} ->
+            register(Node, Pid),
+            _ = update_worker_node_ref({Node, {already_running, false}}),
+            Node;).
 -define(STOP_PEER_NODE(Name),
         peer:stop(Name)).
 -else.
--define(START_PEER_NODE(Name),
-        begin
-            HostName = list_to_atom(net_adm:localhost()),
-            slave:start_link(HostName, Name)
-        end).
+-define(CASE_START_PEER_NODE(Name),
+        case slave:start_link(_HostName = list_to_atom(net_adm:localhost()), Name) of).
 -define(STOP_PEER_NODE(Name),
         slave:stop(Node)).
 -endif.

--- a/include/proper_internal.hrl
+++ b/include/proper_internal.hrl
@@ -33,16 +33,23 @@
 
 -if (?OTP_RELEASE >= 25).
 -define(CASE_START_PEER_NODE(Name),
-    case peer:start(#{name => Name}) of
+    case peer:start_link(#{name => Name}) of
         {ok, Pid, Node} ->
             register(Node, Pid),
             _ = update_worker_node_ref({Node, {already_running, false}}),
+            Node;
+        {ok, Pid} ->
+            Node = list_to_atom(lists:concat([Name, "@", net_adm:localhost()])),
+            register(Node, Pid),
             Node;).
 -define(STOP_PEER_NODE(Name),
         peer:stop(Name)).
 -else.
 -define(CASE_START_PEER_NODE(Name),
-        case slave:start_link(_HostName = list_to_atom(net_adm:localhost()), Name) of).
+    case slave:start_link(_HostName = list_to_atom(net_adm:localhost()), Name) of
+        {ok, Node} ->
+            _ = update_worker_node_ref({Node, {already_running, false}}),
+            Node;).
 -define(STOP_PEER_NODE(Name),
         slave:stop(Node)).
 -endif.

--- a/src/proper.erl
+++ b/src/proper.erl
@@ -2388,7 +2388,7 @@ default_strategy_fun() ->
     end.
 
 %% @private
--spec update_worker_node_ref({node() | pid(), {already_running, boolean()}}) -> [node() | pid()].
+-spec update_worker_node_ref({node(), {already_running, boolean()}}) -> [node()].
 update_worker_node_ref(NodeName) ->
     NewMap = case get(worker_nodes) of
 	       undefined -> [NodeName];
@@ -2401,10 +2401,7 @@ update_worker_node_ref(NodeName) ->
 %% crash the BEAM, and loads on it all the needed code.
 -spec start_node(node()) -> node().
 start_node(Name) ->
-    ?CASE_START_PEER_NODE(Name)
-        {ok, Node} ->
-            _ = update_worker_node_ref({Node, {already_running, false}}),
-            Node;
+    ?CASE_START_PEER_NODE(Name) %% most of the case statements are inside the macro
         {error, {already_running, Node}} ->
             _ = update_worker_node_ref({Node, {already_running, true}}),
             Node

--- a/src/proper.erl
+++ b/src/proper.erl
@@ -414,12 +414,6 @@
 
 -include("proper_internal.hrl").
 
-%% Remove this once PropEr requires at the very least OTP25 to run.
-%% Context: the function has a pattern matching that can
-%% only match in OTP25, so in older versions of OTP Dialyzer
-%% will emit a warning about it.
--dialyzer({nowarn_function, start_node/1}).
-
 %%-----------------------------------------------------------------------------
 %% Macros
 %%-----------------------------------------------------------------------------
@@ -2394,7 +2388,7 @@ default_strategy_fun() ->
     end.
 
 %% @private
--spec update_worker_node_ref({node(), {already_running, boolean()}}) -> [node()].
+-spec update_worker_node_ref({node() | pid(), {already_running, boolean()}}) -> [node() | pid()].
 update_worker_node_ref(NodeName) ->
     NewMap = case get(worker_nodes) of
 	       undefined -> [NodeName];
@@ -2407,12 +2401,8 @@ update_worker_node_ref(NodeName) ->
 %% crash the BEAM, and loads on it all the needed code.
 -spec start_node(node()) -> node().
 start_node(Name) ->
-    case ?START_PEER_NODE(Name) of
+    ?CASE_START_PEER_NODE(Name)
         {ok, Node} ->
-            _ = update_worker_node_ref({Node, {already_running, false}}),
-            Node;
-        {ok, Pid, Node} ->
-            register(Node, Pid),
             _ = update_worker_node_ref({Node, {already_running, false}}),
             Node;
         {error, {already_running, Node}} ->

--- a/src/proper.erl
+++ b/src/proper.erl
@@ -2401,7 +2401,7 @@ update_worker_node_ref(NodeName) ->
 %% crash the BEAM, and loads on it all the needed code.
 -spec start_node(node()) -> node().
 start_node(Name) ->
-    ?CASE_START_PEER_NODE(Name) %% most of the case statements are inside the macro
+    ?CASE_START_PEER_NODE(Name) %% the 'ok' case of this case statement is in the macro
         {error, {already_running, Node}} ->
             _ = update_worker_node_ref({Node, {already_running, true}}),
             Node


### PR DESCRIPTION
Address the deprecation of the old `slave` module in OTP 25.x. To do so, two new macros `?START_PEER_NODE/1` and `?STOP_PEER_NODE/1` have been added, which handle the node setup and teardown properly depending on the OTP version PropEr was compiled with.

I also took the chance to improve the naming in the codebase around said nodes, and to make the code a bid cleaner.

Fixes #293 