### PR TITLE
Upgrade codecov action from v1 to v3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,6 @@ jobs:
         env:
           COVER: true
       - name: Ping codecov
-        uses: codecov/codecov-action@v1
+        uses: codecov/codecov-action@v3
         with:
-          file: "_build/test/covertool/proper.covertool.xml"
+          files: "_build/test/covertool/proper.covertool.xml"


### PR DESCRIPTION
Codecov v1 has been deprecated since February 2022. Try to upgrade directly to version 3.