### PR TITLE
readme: fix correct git clone URI

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Quickstart guide
     base:
 
     ```shell
-    git clone git://github.com/proper-testing/proper.git
+    git clone https://github.com/proper-testing/proper.git
     ```
 *   Compile PropEr: Simply run `make` if you just want to build PropEr.
     If you want to do some changes to PropEr or submit some pull request you


### PR DESCRIPTION
This commit fixes the URI for the call `git clone`. It used to be:
```git
git clone git://github.com/proper-testing/proper.git
```
but it has been replaced by:
```git
git clone https://github.com/proper-testing/proper.git
```
I got timeouts when calling `git clone git://github.com/proper-testing/proper.git`.