### PR TITLE
Test also with Erlang/OTP 25.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         otp:
-          - "25.1.1"
+          - "25.2"
           - "25.0"
           - "24.3"
           - "24.0"
@@ -44,7 +44,7 @@ jobs:
   examples:
     name: Test examples
     runs-on: ubuntu-latest
-    container: erlang:25.1.1
+    container: erlang:25.2
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -54,7 +54,7 @@ jobs:
   parallel-examples:
     name: Test examples in parallel
     runs-on: ubuntu-latest
-    container: erlang:25.1.1
+    container: erlang:25.2
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -64,7 +64,7 @@ jobs:
   coverage:
     name: Code coverage
     runs-on: ubuntu-latest
-    container: erlang:25.1.1
+    container: erlang:25.2
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -74,7 +74,7 @@ jobs:
         run: make test
         env:
           COVER: true
-      - name: Ping codecov
+      - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
         with:
           files: "_build/test/covertool/proper.covertool.xml"

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ base since 2012.
 
 You can reach PropEr's developers in the following ways:
 
-*   on the web: at [the project's home page](http://proper-testing.github.io)
+*   on the web: at [the project's home page](https://proper-testing.github.io)
     or [the project's github page](https://github.com/proper-testing/proper)
 *   by email: take the tool's name (all lowercase), add a @ followed by
     softlab dot ntua dot gr
@@ -89,7 +89,7 @@ Quickstart guide
     base:
 
     ```shell
-    git clone git://github.com/proper-testing/proper.git
+    git clone git@github.com:proper-testing/proper.git
     ```
 *   Compile PropEr: Simply run `make` if you just want to build PropEr.
     If you want to do some changes to PropEr or submit some pull request you
@@ -195,7 +195,7 @@ incompatibilities between the two tools by now.
 <!-- Badges (alphabetically) -->
 [codecov badge]: https://codecov.io/gh/proper-testing/proper/branch/master/graph/badge.svg
 [commit badge]: https://img.shields.io/github/last-commit/proper-testing/proper.svg?style=flat-square
-[erlang versions badge]: https://img.shields.io/badge/erlang-21.0%20to%2025.1-blue.svg?style=flat-square
+[erlang versions badge]: https://img.shields.io/badge/erlang-21.0%20to%2025.2-blue.svg?style=flat-square
 [hex pm badge]: https://img.shields.io/hexpm/v/proper.svg?style=flat
 [license badge]: https://img.shields.io/github/license/proper-testing/proper.svg?style=flat-square
 [release badge]: https://img.shields.io/github/release/proper-testing/proper.svg?style=flat-square


### PR DESCRIPTION
Since this PR would update the README anyway, took the opportunity to also fix the erroneous URI mentioned in the git clone command. (Thanks to @kikofernandez for noticing the issue in PR #302.)