### PR TITLE
Run post_hooks (sh script) on *nixes only

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -55,7 +55,7 @@
                        proper_unused_imports_remover,
                        vararg]}]}]}.
 
-{post_hooks, [{clean, "./scripts/clean_doc.sh"}]}.
+{post_hooks, [{"(linux|darwin|solaris)", clean, "./scripts/clean_doc.sh"}]}.
 
 {dialyzer, [{warnings, [unmatched_returns, unknown]},
             {plt_extra_apps, [erts, kernel, stdlib, compiler, crypto, syntax_tools]}]}.

--- a/rebar.config
+++ b/rebar.config
@@ -55,7 +55,7 @@
                        proper_unused_imports_remover,
                        vararg]}]}]}.
 
-{post_hooks, [{"(linux|darwin|solaris)", clean, "./scripts/clean_doc.sh"}]}.
+{post_hooks, [{"(linux|darwin|solaris|freebsd|netbsd|openbsd)", clean, "./scripts/clean_doc.sh"}]}.
 
 {dialyzer, [{warnings, [unmatched_returns, unknown]},
             {plt_extra_apps, [erts, kernel, stdlib, compiler, crypto, syntax_tools]}]}.


### PR DESCRIPTION
Running `.\rebar.cmd clean` inside the proper dir on Windows will result in the following error:

```
WARN:  Missing plugins: [covertool]
==> proper (clean)
'.' is not recognized as an internal or external command,
ERROR: Command [clean] failed!
operable program or batch file.
```

Solution:
Run this post hook only on *nixes.