### PR TITLE
Move cleanup logic into Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# Copyright 2010-2022 Manolis Papadakis <manopapad@gmail.com>,
+# Copyright 2010-2023 Manolis Papadakis <manopapad@gmail.com>,
 #                     Eirini Arvaniti <eirinibob@gmail.com>,
 #                 and Kostis Sagonas <kostis@cs.ntua.gr>
 #
@@ -72,11 +72,13 @@ doc: compile
 
 clean:
 	./scripts/clean_temp.sh
+	./scripts/clean_doc.sh
+	$(REBAR3) clean
 
 distclean: clean
-	$(REBAR3) clean
-	$(RM) .plt/proper_plt
-	$(RM) -r _build ebin rebar3 rebar.lock
+	$(RM) ebin .plt/proper_plt
+	$(RM) rebar3 rebar.lock
+	$(RM) -r _build
 
 rebuild: distclean compile
 

--- a/rebar.config
+++ b/rebar.config
@@ -1,6 +1,6 @@
 %%% -*- coding: utf-8; erlang-indent-level: 2 -*-
 %%% -------------------------------------------------------------------
-%%% Copyright 2010-2022 Manolis Papadakis <manopapad@gmail.com>,
+%%% Copyright 2010-2023 Manolis Papadakis <manopapad@gmail.com>,
 %%%                     Eirini Arvaniti <eirinibob@gmail.com>,
 %%%                 and Kostis Sagonas <kostis@cs.ntua.gr>
 %%%
@@ -55,7 +55,7 @@
                        proper_unused_imports_remover,
                        vararg]}]}]}.
 
-{post_hooks, [{clean, "./scripts/clean_doc.sh"}]}.
+{post_hooks, []}.
 
 {dialyzer, [{warnings, [unmatched_returns, unknown]},
             {plt_extra_apps, [erts, kernel, stdlib, compiler, crypto, syntax_tools]}]}.


### PR DESCRIPTION
PR #308 brought up the issue that the `clean` command of rebar3 had a Unix-based script as a `post_hook` that could not be run on Windows. Rather that adopting #308 and run the risk of leaving out some OSes, move all cleanup logic, including calling cleanup scripts, to the Makefile instead. This should avoid `rebar3 clean` crashing on Windows.

While at it, move the `rebar3 clean` call from the `distclean` to the `clean` target of Makefile, which seems more standard.

Closes #308