### PR TITLE
enable building proper with OTP-29

### DIFF
--- a/src/proper_erlang_abstract_code.erl
+++ b/src/proper_erlang_abstract_code.erl
@@ -2135,7 +2135,7 @@ check_option(types, Term) ->
     end;
 check_option(records, Term) ->
     try
-        lists:all(fun(R) -> is_record(R) end, Term)
+        lists:all(fun(R) -> proper_is_record(R) end, Term)
     catch
         _:_ ->
             false
@@ -2171,7 +2171,7 @@ is_variable(T) ->
 
 is_fa({F, A}) when is_atom(F), is_integer(A), A >= 0, A < 256 -> true.
 
-is_record({R, Fs}) when is_atom(R) ->
+proper_is_record({R, Fs}) when is_atom(R) ->
     true = lists:all(fun erlang:is_atom/1, Fs).
 
 eval_options([], State) ->

--- a/src/proper_statem.erl
+++ b/src/proper_statem.erl
@@ -767,7 +767,8 @@ pmap(F, L) ->
 		 [command_list()]) -> [pid()].
 spawn_jobs(F, L) ->
     Parent = self(),
-    [spawn_link_cp(fun() -> Parent ! {self(),catch {ok,F(X)}} end) || X <- L].
+    [spawn_link_cp(fun() -> Parent ! {self(),try {ok,F(X)} catch _:R -> {error,R} end} end)
+     || X <- L].
 
 -spec await([pid()]) -> [parallel_history()].
 await([]) -> [];
@@ -775,7 +776,7 @@ await([H|T]) ->
     receive
 	{H, {ok, Res}} ->
 	    [Res|await(T)];
-	{H, {'EXIT',_} = Err} ->
+	{H, {error, Err}} ->
 	    _ = [exit(Pid, kill) || Pid <- T],
 	    _ = [receive {P,_} -> d_ after 0 -> i_ end || P <- T],
 	    erlang:error(Err)

--- a/test/ets_counter.erl
+++ b/test/ets_counter.erl
@@ -81,7 +81,7 @@ set_up() ->
     ok.
 
 clean_up() ->
-    catch ets:delete(counter).
+    try ets:delete(counter) catch _:_ -> ok end.
 
 key() ->
     elements(?KEYS).

--- a/test/ets_statem_test.erl
+++ b/test/ets_statem_test.erl
@@ -228,7 +228,7 @@ prop_ets() ->
     ?FORALL(Type, noshrink(table_type()),
         ?FORALL(Cmds, commands(?MODULE, initial_state(Type)),
 	    begin
-		catch ets:delete(?TAB),
+		try ets:delete(?TAB) catch _:_ -> ok end,
 		?TAB = ets:new(?TAB, [Type, public, named_table]),
 		{H,S,Res} = run_commands(?MODULE, Cmds),
 		clean_up(),
@@ -241,7 +241,7 @@ prop_parallel_ets() ->
     ?FORALL(Type, noshrink(table_type()),
         ?FORALL(Cmds, parallel_commands(?MODULE, initial_state(Type)),
 	    begin
-		catch ets:delete(?TAB),
+		try ets:delete(?TAB) catch _:_ -> ok end,
 		?TAB = ets:new(?TAB, [Type, public, named_table]),
 		{Seq,P,Res} = run_parallel_commands(?MODULE, Cmds),
 		?WHENFAIL(
@@ -254,7 +254,7 @@ prop_parallel_ets() ->
 %%% Utility Functions
 
 set_up() ->
-    catch ets:delete(?TAB),
+    try ets:delete(?TAB) catch _:_ -> ok end,
     Type = lists:nth(proper_arith:rand_int(1, 4),
 		     [set, ordered_set, bag, duplicate_bag]),
     ?TAB = ets:new(?TAB, [Type, public, named_table]).

--- a/test/proper_exported_types_test.erl
+++ b/test/proper_exported_types_test.erl
@@ -52,7 +52,13 @@ not_handled() ->
   R = [{M,T,A,proper_typeserver:demo_translate_type(M, stringify(T, A))}
        || {M,T,A} <- MTs],
   {OKs,Errors} = lists:partition(fun type_translation_is_ok/1, R),
-  {[Inst || TGen <- OKs, (Inst = pick_instance(TGen)) =/= ok], length(Errors)}.
+  {lists:filtermap(fun filtermap_instance/1, OKs), length(Errors)}.
+
+filtermap_instance(TGen) ->
+  case pick_instance(TGen) of
+    ok -> false;
+    Inst -> {true, Inst}
+  end.
 
 pick_instance({M,T,A,{ok,Gen}}) ->
   {ok,Inst} = proper_gen:pick(Gen),

--- a/test/proper_exported_types_test.erl
+++ b/test/proper_exported_types_test.erl
@@ -52,13 +52,7 @@ not_handled() ->
   R = [{M,T,A,proper_typeserver:demo_translate_type(M, stringify(T, A))}
        || {M,T,A} <- MTs],
   {OKs,Errors} = lists:partition(fun type_translation_is_ok/1, R),
-  {lists:filtermap(fun filtermap_instance/1, OKs), length(Errors)}.
-
-filtermap_instance(TGen) ->
-  case pick_instance(TGen) of
-    ok -> false;
-    Inst -> {true, Inst}
-  end.
+  {[Inst || TGen <- OKs, Inst <- [pick_instance(TGen)], Inst =/= ok], length(Errors)}.
 
 pick_instance({M,T,A,{ok,Gen}}) ->
   {ok,Inst} = proper_gen:pick(Gen),

--- a/test/targeted_fsm.erl
+++ b/test/targeted_fsm.erl
@@ -91,7 +91,7 @@ non_empty_ets(S) ->
 prop_random() ->
   ?FORALL(Cmds, proper_fsm:commands(?MODULE),
           begin
-            catch ets:delete(?TAB),
+            try ets:delete(?TAB) catch _:_ -> ok end,
             ?TAB = ets:new(?TAB, [set, public, named_table]),
             {H, _S, Res} = proper_fsm:run_commands(?MODULE, Cmds),
             ets:delete(?TAB),
@@ -103,7 +103,7 @@ prop_targeted() ->
   ?FORALL_TARGETED(
      Cmds, proper_fsm:commands(?MODULE),
      begin
-       catch ets:delete(?TAB),
+       try ets:delete(?TAB) catch _:_ -> ok end,
        ?TAB = ets:new(?TAB, [set, public, named_table]),
        {H, {_, S}, Res} = proper_fsm:run_commands(?MODULE, Cmds),
        ets:delete(?TAB),
@@ -116,7 +116,7 @@ prop_targeted_init() ->
   ?FORALL_TARGETED(
      Cmds, proper_fsm:commands(?MODULE, {empty_ets, []}),
      begin
-       catch ets:delete(?TAB),
+       try ets:delete(?TAB) catch _:_ -> ok end,
        ?TAB = ets:new(?TAB, [set, public, named_table]),
        {H, {_, S}, Res} = proper_fsm:run_commands(?MODULE, Cmds),
        ets:delete(?TAB),

--- a/test/targeted_statem.erl
+++ b/test/targeted_statem.erl
@@ -86,7 +86,7 @@ postcondition(_S, _C, _R) -> true.
 prop_random() ->
   ?FORALL(Cmds, commands(?MODULE),
           begin
-            catch ets:delete(?TAB),
+            try ets:delete(?TAB) catch _:_ -> ok end,
             ?TAB = ets:new(?TAB, [set, public, named_table]),
             {_H, _S, Res} = run_commands(?MODULE, Cmds),
             ets:delete(?TAB),
@@ -96,7 +96,7 @@ prop_random() ->
 prop_targeted() ->
   ?FORALL_TARGETED(Cmds, commands(?MODULE),
                    begin
-                     catch ets:delete(?TAB),
+                     try ets:delete(?TAB) catch _:_ -> ok end,
                      ?TAB = ets:new(?TAB, [set, public, named_table]),
                      {_H, S, Res} = run_commands(?MODULE, Cmds),
                      ets:delete(?TAB),
@@ -107,7 +107,7 @@ prop_targeted() ->
 prop_targeted_init() ->
   ?FORALL_TARGETED(Cmds, commands(?MODULE, []),
                    begin
-                     catch ets:delete(?TAB),
+                     try ets:delete(?TAB) catch _:_ -> ok end,
                      ?TAB = ets:new(?TAB, [set, public, named_table]),
                      {_H, S, Res} = run_commands(?MODULE, Cmds),
                      ets:delete(?TAB),


### PR DESCRIPTION
- eliminate old-style catches
- resolve is_record/1 ambiguity
- fix variable exported from subexpression